### PR TITLE
feat(deploy): wire planforge HTTP service into compose + secrets flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,13 @@ GITHUB_OWNER=LanNguyenSi
 # Optional (defaults shown)
 # FORGE_TEMP_DIR=/tmp/project-forge
 
+# agent-planforge HTTP service (ADR-0002). Required on VPS deploys that run
+# the planforge container alongside project-forge. Generate a fresh random
+# token:  openssl rand -hex 32
+# The same value must be set in both the project-forge and planforge
+# containers — compose propagates it via the shared .env.
+PLANFORGE_SERVICE_TOKEN=
+
 # Optional AI providers
 # Local OpenAI-compatible server takes precedence when both are set.
 # LOCAL_AI_BASE_URL=http://127.0.0.1:11434/v1

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ make deploy
 | `NEXTAUTH_SECRET` | Random secret (`openssl rand -hex 32`) |
 | `NEXTAUTH_URL` | Public URL (e.g. `https://project-forge.example.com`) |
 | `DATABASE_URL` | SQLite path (e.g. `file:/data/project-forge.db`) |
-| `PLANFORGE_PATH` | Absolute path to agent-planforge repo |
-| `SCAFFOLDKIT_PATH` | Absolute path to scaffoldkit source directory |
+| `PLANFORGE_PATH` | Absolute path to agent-planforge repo (legacy shell-out, will be removed per [ADR-0002](docs/adrs/0002-tool-decoupling-service-boundary.md)) |
+| `SCAFFOLDKIT_PATH` | Absolute path to scaffoldkit source directory (same note) |
+| `PLANFORGE_SERVICE_TOKEN` | Shared bearer token for the planforge HTTP service. Generate with `openssl rand -hex 32`. Required on VPS deploys that run the `planforge` container from `docker-compose.yml`. Same value in both containers. |
 
 ### Optional
 
@@ -77,22 +78,27 @@ make deploy
 | `FORGE_TEMP_DIR` | Directory for temporary build artifacts (defaults to OS temp dir) |
 | `SCAFFOLDKIT_PYTHON` | Path to Python 3 binary used by scaffoldkit (defaults to `python3`) |
 
-### Docker Compose Volumes
+### Docker Compose
 
-The Docker container needs read access to the tool directories:
+The root `docker-compose.yml` ships two services:
 
-```yaml
-# docker-compose.override.yml
-services:
-  app:
-    environment:
-      PLANFORGE_PATH: /tools/agent-planforge
-    volumes:
-      - /path/to/agent-planforge:/tools/agent-planforge:ro
-      - /path/to/scaffoldkit:/tools/scaffoldkit:ro
+- `app` — the project-forge Next.js runtime
+- `planforge` — the agent-planforge HTTP service (new, per [ADR-0002](docs/adrs/0002-tool-decoupling-service-boundary.md)). Built from `/root/git/agent-planforge/server/Dockerfile`. **Internal-only** — no Traefik labels, no published ports. `app` reaches it via the shared `traefik` docker network at `http://planforge:8223`.
+
+Both services need `PLANFORGE_SERVICE_TOKEN` in `.env`. Compose propagates it; mismatched values cause `app` to get 401s from `planforge`.
+
+During the ADR-0002 sunset window, `app` also carries read-only bind-mounts for `/root/git/agent-planforge` and `/root/git/scaffoldkit` — these feed the legacy shell-out paths and disappear once the client-swap ticket lands.
+
+**Token rotation (manual, v1):**
+
+```bash
+cd /root/git/project-forge
+NEW_TOKEN=$(openssl rand -hex 32)
+sed -i "s/^PLANFORGE_SERVICE_TOKEN=.*/PLANFORGE_SERVICE_TOKEN=$NEW_TOKEN/" .env
+docker compose up -d --build  # rebuild both so the new token is live simultaneously
 ```
 
-See `docker-compose.override.example.yml` for a full example.
+A token store + in-place rotation is a follow-up (see ADR-0002).
 
 ## API
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,17 @@ services:
       PORT: "3000"
       GITHUB_TOKEN: ${GITHUB_TOKEN}
       GITHUB_OWNER: ${GITHUB_OWNER:-LanNguyenSi}
+      # Legacy shell-out paths — kept during the ADR-0002 sunset window
+      # (see `lib/planforge-runner.ts`). The client-swap ticket (agent-tasks
+      # `8080321b`) replaces both with the HTTP call below; ticket #5
+      # (`31e6f7db`) removes these env vars + the bind-mounts entirely.
       PLANFORGE_PATH: /tools/agent-planforge
       SCAFFOLDKIT_PATH: /tools/scaffoldkit
       FORGE_TEMP_DIR: /tmp/project-forge
+      # New HTTP boundary (ADR-0002). project-forge's client swap
+      # consumes these two; until it ships they are wired but unused.
+      PLANFORGE_URL: http://planforge:8223
+      PLANFORGE_SERVICE_TOKEN: ${PLANFORGE_SERVICE_TOKEN}
     volumes:
       - /root/git/agent-planforge:/tools/agent-planforge:ro
       - /root/git/scaffoldkit:/tools/scaffoldkit:ro
@@ -23,6 +31,46 @@ services:
       traefik.http.routers.project-forge.entrypoints: websecure
       traefik.http.routers.project-forge.tls.certresolver: letsencrypt
       traefik.http.services.project-forge.loadbalancer.server.port: "3000"
+    depends_on:
+      planforge:
+        # Wait until planforge reports healthy so project-forge boots with a
+        # live PLANFORGE_URL target. Without the condition, app would race
+        # the first request and 502 until the Hono server finishes booting.
+        condition: service_healthy
+    networks:
+      - traefik
+    restart: unless-stopped
+
+  # ── agent-planforge HTTP service (ADR-0002 follow-up #4) ────────────────
+  #
+  # Built from the agent-planforge repo checked out at /root/git/agent-planforge
+  # (same bind-mount convention the legacy shell-out uses). The image ships the
+  # planforge CLI, the TypeScript HTTP layer, and a pinned scaffoldkit venv —
+  # see `agent-planforge/server/Dockerfile` for the full breakdown.
+  #
+  # Intentionally NOT Traefik-exposed. Access is scoped to the shared `traefik`
+  # docker network, where project-forge reaches it via the internal DNS name
+  # `planforge:8223`. Anything outside the network is invisible to it.
+  planforge:
+    build:
+      context: /root/git/agent-planforge
+      dockerfile: server/Dockerfile
+    environment:
+      PLANFORGE_SERVICE_TOKEN: ${PLANFORGE_SERVICE_TOKEN}
+    # No ports: — traffic stays on the internal docker network. No Traefik
+    # labels either: public exposure would bypass the service-token contract.
+    healthcheck:
+      # Inline Node so we don't have to add curl/wget to the image. /healthz
+      # is unauth (by design), so the probe doesn't need the service token.
+      test:
+        - CMD
+        - node
+        - -e
+        - "require('http').get('http://localhost:8223/healthz', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
     networks:
       - traefik
     restart: unless-stopped


### PR DESCRIPTION
ADR-0002 follow-up #4 (agent-tasks 8d9fe14f).

Compose adds a planforge service (built from /root/git/agent-planforge/server/Dockerfile per PR #58) next to app. Internal-only — reachable at planforge:8223 over the shared traefik network, no Traefik labels/ports. Healthcheck via inline Node against unauth /healthz. app gains PLANFORGE_URL + PLANFORGE_SERVICE_TOKEN (propagated via shared .env) and depends_on: planforge healthy so app does not race the first call.

Legacy bind-mounts stay during ADR-0002 sunset window; ticket 31e6f7db removes them post client-swap.

.env.example gains PLANFORGE_SERVICE_TOKEN with openssl rand -hex 32 recipe; README documents the two-service topology and manual token rotation procedure.

Known v1: manual token rotation, image built from host-bind-mount (GHCR publish is a separate cleanup).