### PR TITLE
feat(planforge): HTTP client + generate-route swap (ADR-0002 v1)

### DIFF
--- a/app/api/v1/generate/route.ts
+++ b/app/api/v1/generate/route.ts
@@ -7,6 +7,7 @@ import type { ErrorResponse } from "@/lib/types";
 import { resolvePlanforgeOutputPaths } from "@/lib/planforge-output";
 import { buildPlanforgeInput } from "@/lib/planforge-orchestrator";
 import { executePlanforgeWorkflow } from "@/lib/planforge-runner";
+import { runPlanforgeViaHttp, PlanforgeClientError } from "@/lib/planforge-client";
 import { runPostScaffoldReview } from "@/lib/post-scaffold-review";
 import { runCommand } from "@/lib/subprocess";
 import { validateProjectName, readPreviewData } from "@/lib/v1-shared";
@@ -14,6 +15,21 @@ import { validateProjectName, readPreviewData } from "@/lib/v1-shared";
 const TEMP_ROOT = process.env.FORGE_TEMP_DIR ?? "/tmp/project-forge";
 const PLANFORGE_PATH = process.env.PLANFORGE_PATH ?? "/root/.openclaw/workspace/git/agent-planforge";
 const GENERATION_TIMEOUT_MS = 30_000;
+
+// ADR-0002 sunset-window flag. Defaults to `http` (the new path) on
+// deploys that set `PLANFORGE_URL`; falls back to `shell` (legacy
+// subprocess) on boxes that don't have the planforge service deployed
+// alongside. Operators can force either explicitly via `PLANFORGE_MODE`
+// to smoke both paths during the rollout.
+//
+// Once the HTTP path is proven in prod, ticket #5 (`31e6f7db`) removes
+// the shell branch + the Python/scaffoldkit bind-mounts entirely.
+type PlanforgeMode = "shell" | "http";
+function resolvePlanforgeMode(): PlanforgeMode {
+  const explicit = process.env.PLANFORGE_MODE?.toLowerCase();
+  if (explicit === "shell" || explicit === "http") return explicit;
+  return process.env.PLANFORGE_URL ? "http" : "shell";
+}
 
 interface GenerateRequest {
   projectName: string;
@@ -74,15 +90,34 @@ export async function POST(req: NextRequest) {
       targetUsers: input.targetUsers,
     });
 
-    const inputPath = path.join(tempDir, "project-input.json");
-    await fs.writeFile(inputPath, JSON.stringify(planforgeInput, null, 2));
-
-    await executePlanforgeWorkflow({
-      planforgePath: PLANFORGE_PATH,
-      inputPath,
-      outdir: tempDir,
-      timeoutMs: GENERATION_TIMEOUT_MS,
-    });
+    const mode = resolvePlanforgeMode();
+    if (mode === "http") {
+      const baseUrl = process.env.PLANFORGE_URL;
+      const token = process.env.PLANFORGE_SERVICE_TOKEN;
+      if (!baseUrl || !token) {
+        throw new PlanforgeClientError(
+          "PLANFORGE_MODE=http requires both PLANFORGE_URL and PLANFORGE_SERVICE_TOKEN",
+        );
+      }
+      await runPlanforgeViaHttp({
+        baseUrl,
+        token,
+        input: planforgeInput,
+        outdir: tempDir,
+        timeoutMs: GENERATION_TIMEOUT_MS,
+      });
+    } else {
+      // Legacy shell-out path — kept for the ADR-0002 sunset window.
+      // Writes the input to disk so the CLI can read `--input` from it.
+      const inputPath = path.join(tempDir, "project-input.json");
+      await fs.writeFile(inputPath, JSON.stringify(planforgeInput, null, 2));
+      await executePlanforgeWorkflow({
+        planforgePath: PLANFORGE_PATH,
+        inputPath,
+        outdir: tempDir,
+        timeoutMs: GENERATION_TIMEOUT_MS,
+      });
+    }
 
     // Step 2: Run scaffoldkit
     const artifacts = await resolvePlanforgeOutputPaths(tempDir);

--- a/lib/planforge-client.ts
+++ b/lib/planforge-client.ts
@@ -1,0 +1,196 @@
+/**
+ * HTTP client for the agent-planforge service.
+ *
+ * Replaces the `child_process.spawn("node", [bootstrap-plan.js, ...])` path
+ * in `lib/planforge-runner.ts` with a `POST /api/generate` call against the
+ * deployed planforge container. Part of the ADR-0002 decoupling — see
+ * `docs/adrs/0002-tool-decoupling-service-boundary.md`.
+ *
+ * Shape of the exchange:
+ *   1. POST the planforge input JSON to `${PLANFORGE_URL}/api/generate` with
+ *      a Bearer `PLANFORGE_SERVICE_TOKEN`.
+ *   2. Server streams SSE events — `progress` lines forwarded as-is to the
+ *      caller's optional `onProgress` hook so logs keep their existing
+ *      shape, plus a final `done` event carrying `outputTarGz` (base64
+ *      gzipped tarball of the CLI's output dir contents).
+ *   3. Client untars `outputTarGz` into the caller-supplied `outdir`. The
+ *      tar packs directory *contents* (server does `tar -C <dir> .`), so
+ *      extracting straight into `outdir` reproduces the layout the CLI
+ *      would have written there itself — no nested `out/` folder.
+ *   4. Downstream code (`resolvePlanforgeOutputPaths`, scaffoldkit
+ *      shell-out, post-scaffold review, preview read) keeps reading from
+ *      `outdir` exactly as before.
+ *
+ * Keeps the scaffoldkit subprocess in `app/api/v1/generate/route.ts`
+ * untouched for this ticket. Moving scaffoldkit into planforge is a
+ * separate follow-up — sunset window stays open.
+ */
+import { spawn } from "node:child_process";
+
+export interface RunPlanforgeOptions {
+  /** Base URL of the planforge service, e.g. `http://planforge:8223`. */
+  baseUrl: string;
+  /** Shared service token (PLANFORGE_SERVICE_TOKEN). */
+  token: string;
+  /** The planforge input payload — same shape the CLI's `--input` accepts. */
+  input: unknown;
+  /** Local directory to extract the CLI output into. Must already exist. */
+  outdir: string;
+  /**
+   * Optional stream sink for SSE `progress` lines. The string passed is the
+   * raw stdout/stderr line the CLI wrote — matches the old subprocess-stdout
+   * contract so existing progress UIs don't have to change.
+   */
+  onProgress?: (line: string, stream: "stdout" | "stderr") => void;
+  /** Request timeout in ms. The whole POST + SSE + untar cycle. */
+  timeoutMs?: number;
+}
+
+export interface PlanforgeRunResult {
+  requestId: string;
+  planOutput: unknown;
+  scaffoldkitInput: unknown | null;
+}
+
+export class PlanforgeClientError extends Error {
+  constructor(message: string, readonly statusCode?: number) {
+    super(message);
+    this.name = "PlanforgeClientError";
+  }
+}
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+export async function runPlanforgeViaHttp(
+  options: RunPlanforgeOptions,
+): Promise<PlanforgeRunResult> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(new Error("planforge HTTP call timed out")),
+    options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+  try {
+    const res = await fetch(`${options.baseUrl.replace(/\/$/, "")}/api/generate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${options.token}`,
+        Accept: "text/event-stream",
+      },
+      body: JSON.stringify({ input: options.input }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      // Body may carry a JSON error message; try but tolerate plain text.
+      const body = await res.text().catch(() => "");
+      throw new PlanforgeClientError(
+        `planforge service returned ${res.status}: ${body.slice(0, 500)}`,
+        res.status,
+      );
+    }
+    if (!res.body) {
+      throw new PlanforgeClientError("planforge service returned an empty body");
+    }
+
+    // SSE is a sequence of `event:` + `data:` blocks separated by blank
+    // lines. No off-the-shelf parser — the service writes simple frames
+    // (one `event:` line, one `data:` line, then `\n\n`) so we unfold them
+    // in-place instead of pulling an sse-client dep.
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    let doneEvent: {
+      requestId: string;
+      planOutput: unknown;
+      scaffoldkitInput: unknown | null;
+      outputTarGz?: string;
+    } | null = null;
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let frameEnd: number;
+      while ((frameEnd = buf.indexOf("\n\n")) >= 0) {
+        const frame = buf.slice(0, frameEnd);
+        buf = buf.slice(frameEnd + 2);
+        const event = /^event:\s*(.*)$/m.exec(frame)?.[1]?.trim() ?? "message";
+        const data = /^data:\s*(.*)$/m.exec(frame)?.[1] ?? "";
+        if (!data) continue;
+        if (event === "progress") {
+          if (options.onProgress) {
+            try {
+              const payload = JSON.parse(data) as {
+                line?: string;
+                stream?: "stdout" | "stderr";
+              };
+              if (payload.line) options.onProgress(payload.line, payload.stream ?? "stdout");
+            } catch {
+              // Malformed progress frames aren't worth aborting the run.
+            }
+          }
+        } else if (event === "done") {
+          doneEvent = JSON.parse(data);
+        } else if (event === "error") {
+          const payload = JSON.parse(data) as { message?: string; exitCode?: number };
+          throw new PlanforgeClientError(
+            `planforge error (exit ${payload.exitCode ?? "unknown"}): ${payload.message ?? "no message"}`,
+          );
+        }
+      }
+    }
+
+    if (!doneEvent) {
+      throw new PlanforgeClientError("planforge stream ended without a done event");
+    }
+    if (!doneEvent.outputTarGz) {
+      // Older deploys before feat/generate-returns-tarball shipped would
+      // hit this — once the fleet is on the tarball contract (current
+      // deploy state, 2026-04-18+), this branch is unreachable.
+      throw new PlanforgeClientError(
+        "planforge done event did not include outputTarGz — service deploy predates the tarball contract",
+      );
+    }
+
+    await extractTarGzInto(options.outdir, doneEvent.outputTarGz);
+
+    return {
+      requestId: doneEvent.requestId,
+      planOutput: doneEvent.planOutput,
+      scaffoldkitInput: doneEvent.scaffoldkitInput ?? null,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Pipe the base64 gzipped tarball into `tar -xzf - -C outdir`. Going
+ * through the system `tar` binary keeps the dep tree minimal and matches
+ * what the server-side wrote it with, so round-trip semantics (symlinks,
+ * empty dirs, modes) can't drift between packer and unpacker.
+ *
+ * The Next.js production image (node:22-alpine / node:22-slim — see
+ * `Dockerfile`) has GNU tar preinstalled. Bind-mount-based dev on the
+ * host also has it.
+ */
+async function extractTarGzInto(outdir: string, base64: string): Promise<void> {
+  const buf = Buffer.from(base64, "base64");
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn("tar", ["-xzf", "-", "-C", outdir], {
+      stdio: ["pipe", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", (err) => reject(err));
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new PlanforgeClientError(`tar exited ${code}: ${stderr.trim()}`));
+    });
+    child.stdin.end(buf);
+  });
+}

--- a/tests/integration/planforge-client.test.ts
+++ b/tests/integration/planforge-client.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit test for `lib/planforge-client.ts`. Verifies:
+ *   - SSE frames are unfolded correctly, `progress` hooks fire in order.
+ *   - `done` event's `outputTarGz` is base64-decoded + extracted via
+ *     system `tar`, reproducing the expected file layout.
+ *   - `error` events abort with a PlanforgeClientError carrying the
+ *     message.
+ *   - HTTP-level failures (non-2xx, empty body) fail loudly.
+ *
+ * No live service required — the fetch is mocked and the tarball is
+ * constructed on the fly from a known temp tree.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { runPlanforgeViaHttp, PlanforgeClientError } from "../../lib/planforge-client";
+
+const execFileP = promisify(execFile);
+
+async function buildFixtureTarGzB64(): Promise<string> {
+  const src = await mkdtemp(resolve(tmpdir(), "client-fixture-src-"));
+  try {
+    await mkdir(resolve(src, "planning"), { recursive: true });
+    await mkdir(resolve(src, "exports"), { recursive: true });
+    await writeFile(resolve(src, "planforge-index.json"), JSON.stringify({ generatedBy: "agent-planforge" }));
+    await writeFile(resolve(src, "planning", "plan-output.json"), JSON.stringify({ projectName: "Test" }));
+    await writeFile(resolve(src, "exports", "scaffoldkit-input.json"), JSON.stringify({ blueprint: "none" }));
+    const { stdout } = await execFileP("tar", ["-czf", "-", "-C", src, "."], { encoding: "buffer" });
+    return stdout.toString("base64");
+  } finally {
+    await rm(src, { recursive: true, force: true });
+  }
+}
+
+function sseResponse(events: Array<{ event: string; data: unknown }>): Response {
+  const body = events
+    .map((e) => `event: ${e.event}\ndata: ${JSON.stringify(e.data)}\n\n`)
+    .join("");
+  // Stream it in chunks so the frame reassembler actually gets exercised.
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const chunks = body.match(/[\s\S]{1,40}/g) ?? [body];
+      for (const c of chunks) controller.enqueue(new TextEncoder().encode(c));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+describe("runPlanforgeViaHttp", () => {
+  let outdir: string;
+  const realFetch = global.fetch;
+
+  beforeEach(async () => {
+    outdir = await mkdtemp(resolve(tmpdir(), "planforge-client-out-"));
+  });
+  afterEach(async () => {
+    await rm(outdir, { recursive: true, force: true });
+    global.fetch = realFetch;
+  });
+
+  it("extracts the tarball and returns structured done data", async () => {
+    const tarGz = await buildFixtureTarGzB64();
+    const progress: string[] = [];
+    global.fetch = vi.fn().mockResolvedValue(
+      sseResponse([
+        { event: "progress", data: { line: "Generated planning artifacts", stream: "stdout" } },
+        {
+          event: "done",
+          data: {
+            requestId: "req-1",
+            planOutput: { projectName: "Test" },
+            scaffoldkitInput: { blueprint: "none" },
+            outputTarGz: tarGz,
+            exitCode: 0,
+          },
+        },
+      ]),
+    ) as unknown as typeof fetch;
+
+    const result = await runPlanforgeViaHttp({
+      baseUrl: "http://planforge:8223",
+      token: "t",
+      input: { projectName: "Test" },
+      outdir,
+      onProgress: (line) => progress.push(line),
+    });
+
+    expect(result.requestId).toBe("req-1");
+    expect(result.planOutput).toEqual({ projectName: "Test" });
+    expect(progress).toEqual(["Generated planning artifacts"]);
+
+    // Verify the CLI's file layout appears on disk.
+    const planforgeIndex = JSON.parse(
+      await readFile(resolve(outdir, "planforge-index.json"), "utf8"),
+    );
+    expect(planforgeIndex.generatedBy).toBe("agent-planforge");
+    const planOutput = JSON.parse(
+      await readFile(resolve(outdir, "planning", "plan-output.json"), "utf8"),
+    );
+    expect(planOutput.projectName).toBe("Test");
+    const skInput = JSON.parse(
+      await readFile(resolve(outdir, "exports", "scaffoldkit-input.json"), "utf8"),
+    );
+    expect(skInput.blueprint).toBe("none");
+  });
+
+  it("throws PlanforgeClientError on an `error` SSE frame", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      sseResponse([
+        { event: "error", data: { message: "planforge CLI crashed", exitCode: 2 } },
+      ]),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      runPlanforgeViaHttp({
+        baseUrl: "http://planforge:8223",
+        token: "t",
+        input: {},
+        outdir,
+      }),
+    ).rejects.toThrow(/planforge CLI crashed/);
+  });
+
+  it("throws when the HTTP response is non-2xx", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response("forbidden", { status: 403 }),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      runPlanforgeViaHttp({
+        baseUrl: "http://planforge:8223",
+        token: "bad",
+        input: {},
+        outdir,
+      }),
+    ).rejects.toThrow(PlanforgeClientError);
+  });
+
+  it("throws when the stream ends without a done event", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      sseResponse([
+        { event: "progress", data: { line: "hello", stream: "stdout" } },
+      ]),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      runPlanforgeViaHttp({
+        baseUrl: "http://planforge:8223",
+        token: "t",
+        input: {},
+        outdir,
+      }),
+    ).rejects.toThrow(/done event/);
+  });
+
+  it("throws when done arrives without outputTarGz (service predates tarball contract)", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      sseResponse([
+        {
+          event: "done",
+          data: { requestId: "req-2", planOutput: {}, scaffoldkitInput: null, exitCode: 0 },
+        },
+      ]),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      runPlanforgeViaHttp({
+        baseUrl: "http://planforge:8223",
+        token: "t",
+        input: {},
+        outdir,
+      }),
+    ).rejects.toThrow(/outputTarGz/);
+  });
+});


### PR DESCRIPTION
Resolves agent-tasks task 8080321b (ADR-0002 follow-up #3).

Replaces the planforge subprocess in app/api/v1/generate/route.ts with a POST to the deployed agent-planforge HTTP service. Depends on agent-planforge#60 (tarball contract) — already merged + deployed on VPS_01.

## Client (lib/planforge-client.ts)
- POSTs to PLANFORGE_URL/api/generate with Bearer PLANFORGE_SERVICE_TOKEN
- SSE reassembly without extra deps; progress lines forward to an optional hook
- On done: base64-decode outputTarGz + pipe through tar -xzf into outdir. Downstream code (resolvePlanforgeOutputPaths, scaffoldkit shell-out, preview read) sees the same file tree it would have gotten from the subprocess path.
- PlanforgeClientError wraps error SSE frames, non-2xx HTTP, stream-without-done, and pre-tarball service deploys

## Route
- PLANFORGE_MODE=shell|http flag (auto-picks http when PLANFORGE_URL is set)
- Legacy subprocess kept for the sunset window — ticket 31e6f7db removes it + the Python/scaffoldkit bind-mounts
- Scaffoldkit still local; moving it server-side is a separate follow-up

## Tests
- tests/integration/planforge-client.test.ts: mock fetch + chunked SSE, asserts tarball extraction, error/non-2xx/no-done/missing-outputTarGz paths
- 21 tests pass total, Next.js build clean

## Live smoke (pre-push)
POST /api/generate against the deployed planforge returned 44 KB SSE with `done` + `outputTarGz`. Tarball contract verified end-to-end in prod.

## Rollout
No env change required — compose already has PLANFORGE_URL + PLANFORGE_SERVICE_TOKEN from ticket 8d9fe14f. After merge + app rebuild, PLANFORGE_MODE=http activates automatically. To rollback: set PLANFORGE_MODE=shell and restart app.