### PR TITLE
feat(auth): add register-from-project-pilot identity-broker endpoint

### DIFF
--- a/app/api/auth/register-from-project-pilot/route.ts
+++ b/app/api/auth/register-from-project-pilot/route.ts
@@ -1,0 +1,165 @@
+/**
+ * Identity-broker registration endpoint.
+ *
+ * Contract (shared with agent-tasks, deploy-panel):
+ *   POST /api/auth/register-from-project-pilot
+ *   Body:     { githubAccessToken: string, githubLogin?: string }
+ *   Response: { apiToken, userId, githubLogin }
+ *   Errors:   401 invalid token / login mismatch
+ *             503 GitHub unreachable
+ *             400 missing fields
+ *
+ * project-forge does NOT blindly trust the caller (project-pilot). The
+ * access-token is re-verified against `api.github.com/user`. A compromised
+ * broker cannot impersonate users because the token has to be valid.
+ *
+ * The returned apiToken is project-forge's own `pf_*` API token — the broker
+ * stores it encrypted and forwards it on subsequent API calls. Idempotent:
+ * a second call for the same GitHub identity returns the existing active
+ * token rather than minting a new one.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { prisma, generateApiToken } from "@/lib/db";
+import {
+  fetchGitHubUser,
+  GitHubAuthError,
+  GitHubUnreachableError,
+} from "@/lib/github";
+
+interface RegisterBody {
+  githubAccessToken: unknown;
+  githubLogin?: unknown;
+}
+
+export async function POST(req: NextRequest) {
+  let body: RegisterBody;
+  try {
+    body = (await req.json()) as RegisterBody;
+  } catch {
+    return NextResponse.json(
+      { error: "bad_request", message: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  if (typeof body.githubAccessToken !== "string" || body.githubAccessToken.length === 0) {
+    return NextResponse.json(
+      { error: "bad_request", message: "githubAccessToken is required" },
+      { status: 400 },
+    );
+  }
+  if (body.githubLogin !== undefined && typeof body.githubLogin !== "string") {
+    return NextResponse.json(
+      { error: "bad_request", message: "githubLogin must be a string if provided" },
+      { status: 400 },
+    );
+  }
+
+  let githubUser;
+  try {
+    githubUser = await fetchGitHubUser(body.githubAccessToken);
+  } catch (err) {
+    if (err instanceof GitHubAuthError) {
+      return NextResponse.json(
+        { error: "unauthorized", message: "GitHub access-token verification failed" },
+        { status: 401 },
+      );
+    }
+    if (err instanceof GitHubUnreachableError) {
+      return NextResponse.json(
+        {
+          error: "upstream_unavailable",
+          message: "Could not reach GitHub to verify access-token; retry shortly",
+        },
+        { status: 503 },
+      );
+    }
+    return NextResponse.json(
+      { error: "internal", message: "Unexpected error verifying access-token" },
+      { status: 500 },
+    );
+  }
+
+  if (body.githubLogin && body.githubLogin !== githubUser.login) {
+    return NextResponse.json(
+      {
+        error: "unauthorized",
+        message: "Claimed githubLogin does not match verified GitHub identity",
+      },
+      { status: 401 },
+    );
+  }
+
+  const githubId = String(githubUser.id);
+  const githubEmail = githubUser.email?.toLowerCase() ?? null;
+
+  // Lookup by githubId first (stable across GitHub rename).
+  const existingByGithubId = await prisma.user.findUnique({ where: { githubId } });
+
+  // Email-collision guard: if the verified GitHub email matches a local-auth
+  // account that has NO githubId yet, we refuse to silently merge the two.
+  // Otherwise anyone who controls that email on GitHub could claim the local
+  // account. Surface a structured 409 so project-pilot can prompt the user
+  // to sign in locally first and link GitHub explicitly.
+  if (!existingByGithubId && githubEmail) {
+    const existingByEmail = await prisma.user.findUnique({ where: { email: githubEmail } });
+    if (existingByEmail && !existingByEmail.githubId) {
+      return NextResponse.json(
+        {
+          error: "account_exists_link_required",
+          message:
+            "An account with this email already exists. Sign in with your " +
+            "existing credentials first, then link GitHub.",
+        },
+        { status: 409 },
+      );
+    }
+  }
+
+  const user = existingByGithubId
+    ? await prisma.user.update({
+        where: { id: existingByGithubId.id },
+        data: {
+          githubLogin: githubUser.login,
+          email: githubEmail ?? existingByGithubId.email,
+          // Keep githubPat/githubOwner/passwordHash untouched — this endpoint
+          // never overwrites existing project-forge-specific credentials.
+        },
+      })
+    : await prisma.user.create({
+        data: {
+          githubId,
+          githubLogin: githubUser.login,
+          email: githubEmail,
+          // OAuth-provisioned users have no password; column is nullable.
+        },
+      });
+
+  // Idempotency: reuse an existing unrevoked token for this user rather than
+  // minting a new one on every broker call. The broker is expected to cache
+  // the returned token and only re-register on 401.
+  const activeToken = await prisma.apiToken.findFirst({
+    where: { userId: user.id, revokedAt: null, name: "project-pilot" },
+    orderBy: { createdAt: "desc" },
+  });
+
+  let apiToken: string;
+  if (activeToken) {
+    apiToken = activeToken.token;
+  } else {
+    apiToken = generateApiToken();
+    await prisma.apiToken.create({
+      data: {
+        token: apiToken,
+        name: "project-pilot",
+        userId: user.id,
+      },
+    });
+  }
+
+  return NextResponse.json({
+    apiToken,
+    userId: user.id,
+    githubLogin: githubUser.login,
+  });
+}

--- a/app/api/v1/projects/route.ts
+++ b/app/api/v1/projects/route.ts
@@ -207,7 +207,7 @@ export async function POST(req: NextRequest) {
       tempDir,
       input.projectName,
       user.githubPat,
-      user.githubOwner || user.email.split("@")[0]
+      user.githubOwner || user.githubLogin || user.email?.split("@")[0] || "user"
     );
 
     // Log usage

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,4 @@
-import type { NextAuthOptions, Account } from "next-auth";
+import type { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import GitHubProvider from "next-auth/providers/github";
 import { prisma } from "./db";
@@ -24,7 +24,9 @@ export const authOptions: NextAuthOptions = {
         const user = await prisma.user.findUnique({
           where: { email: credentials.email },
         });
-        if (!user) return null;
+        // OAuth-only users have no passwordHash — treat them as
+        // non-local-auth to avoid leaking account existence.
+        if (!user || !user.passwordHash || !user.email) return null;
         const valid = await bcrypt.compare(credentials.password, user.passwordHash);
         if (!valid) return null;
         return { id: user.id, email: user.email };
@@ -49,7 +51,10 @@ export const authOptions: NextAuthOptions = {
           },
           create: {
             email,
-            passwordHash: "", // no password for OAuth users
+            // OAuth users have no local password. passwordHash stays null so
+            // the Credentials provider's `!user.passwordHash` guard can
+            // reject them cleanly without a sentinel-string collision.
+            passwordHash: null,
             githubPat: account.access_token,
             githubOwner: githubUsername,
           },

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,0 +1,61 @@
+/**
+ * Minimal GitHub API helper.
+ *
+ * Used by the identity-broker registration endpoint to verify an access-token
+ * actually belongs to the claimed user. Deliberately thin — we only need the
+ * `/user` endpoint and we want to classify failure modes (invalid token vs
+ * upstream unreachable) so the broker can distinguish "re-auth required"
+ * from "retry in a moment".
+ */
+
+export interface GitHubUser {
+  id: number;
+  login: string;
+  name: string | null;
+  avatar_url: string;
+  email: string | null;
+}
+
+export class GitHubAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GitHubAuthError";
+  }
+}
+
+export class GitHubUnreachableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GitHubUnreachableError";
+  }
+}
+
+export async function fetchGitHubUser(accessToken: string): Promise<GitHubUser> {
+  let response: Response;
+  try {
+    response = await fetch("https://api.github.com/user", {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/vnd.github+json",
+      },
+    });
+  } catch (err) {
+    throw new GitHubUnreachableError(
+      `Could not reach GitHub: ${(err as Error).message}`,
+    );
+  }
+
+  if (response.status === 401 || response.status === 403 || response.status === 404) {
+    throw new GitHubAuthError(
+      `GitHub rejected the access-token (${response.status})`,
+    );
+  }
+  if (!response.ok) {
+    // 5xx or other transient — tell the caller to retry.
+    throw new GitHubUnreachableError(
+      `GitHub API returned ${response.status}`,
+    );
+  }
+
+  return response.json() as Promise<GitHubUser>;
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,9 +8,17 @@ datasource db {
 }
 
 model User {
+  // Users originate either from local email/password registration
+  // (email + passwordHash populated) or from an identity broker like
+  // project-pilot via GitHub OAuth (githubId populated, password/email
+  // optional since GitHub may hide the email). Hence both `email` and
+  // `passwordHash` are nullable; at least one of them or `githubId` is
+  // always set in practice.
   id           String     @id @default(cuid())
-  email        String     @unique
-  passwordHash String
+  email        String?    @unique
+  passwordHash String?
+  githubId     String?    @unique
+  githubLogin  String?
   githubPat    String?
   githubOwner  String?
   createdAt    DateTime   @default(now())

--- a/tests/integration/register-from-project-pilot.test.ts
+++ b/tests/integration/register-from-project-pilot.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock the Prisma client before importing the route.
+vi.mock("@/lib/db", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/db")>("@/lib/db");
+  return {
+    ...actual,
+    prisma: {
+      user: { findUnique: vi.fn(), update: vi.fn(), create: vi.fn() },
+      apiToken: { findFirst: vi.fn(), create: vi.fn() },
+    },
+  };
+});
+
+vi.mock("@/lib/github", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/github")>("@/lib/github");
+  return {
+    ...actual,
+    fetchGitHubUser: vi.fn(),
+  };
+});
+
+import { prisma } from "@/lib/db";
+import { fetchGitHubUser, GitHubAuthError, GitHubUnreachableError } from "@/lib/github";
+import { POST } from "@/app/api/auth/register-from-project-pilot/route";
+import { NextRequest } from "next/server";
+
+const fetchMock = vi.mocked(fetchGitHubUser);
+const user = prisma.user as unknown as {
+  findUnique: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+};
+const apiToken = prisma.apiToken as unknown as {
+  findFirst: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+};
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://test/api/auth/register-from-project-pilot", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/register-from-project-pilot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("400 when githubAccessToken is missing", async () => {
+    const res = await POST(makeReq({ githubLogin: "lan" }));
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("401 when GitHub rejects the token", async () => {
+    fetchMock.mockRejectedValue(new GitHubAuthError("401 Unauthorized"));
+    const res = await POST(makeReq({ githubAccessToken: "bad" }));
+    expect(res.status).toBe(401);
+    expect(user.create).not.toHaveBeenCalled();
+  });
+
+  it("503 when GitHub is unreachable", async () => {
+    fetchMock.mockRejectedValue(new GitHubUnreachableError("ENOTFOUND"));
+    const res = await POST(makeReq({ githubAccessToken: "good-but-offline" }));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("upstream_unavailable");
+  });
+
+  it("401 when claimed githubLogin does not match verified identity", async () => {
+    fetchMock.mockResolvedValue({
+      id: 7,
+      login: "actual",
+      name: null,
+      avatar_url: "",
+      email: null,
+    });
+    const res = await POST(makeReq({
+      githubAccessToken: "valid",
+      githubLogin: "pretender",
+    }));
+    expect(res.status).toBe(401);
+    expect(user.create).not.toHaveBeenCalled();
+  });
+
+  it("provisions a new user and issues an API token on first call", async () => {
+    fetchMock.mockResolvedValue({
+      id: 42,
+      login: "newbie",
+      name: "New",
+      avatar_url: "",
+      email: "new@example.com",
+    });
+    user.findUnique.mockResolvedValue(null);
+    user.create.mockResolvedValue({ id: "user-1" });
+    apiToken.findFirst.mockResolvedValue(null);
+    apiToken.create.mockResolvedValue({});
+
+    const res = await POST(makeReq({ githubAccessToken: "valid", githubLogin: "newbie" }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.userId).toBe("user-1");
+    expect(body.githubLogin).toBe("newbie");
+    expect(body.apiToken).toMatch(/^pf_/);
+    expect(apiToken.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("409 when the verified GitHub email collides with a local-auth account (no githubId)", async () => {
+    fetchMock.mockResolvedValue({
+      id: 123,
+      login: "newcomer",
+      name: null,
+      avatar_url: "",
+      email: "victim@example.com",
+    });
+    // No existing githubId match…
+    user.findUnique
+      .mockResolvedValueOnce(null)
+      // …but a local-auth user already owns the email.
+      .mockResolvedValueOnce({
+        id: "local-victim",
+        email: "victim@example.com",
+        passwordHash: "hashed",
+        githubId: null,
+      });
+
+    const res = await POST(makeReq({ githubAccessToken: "valid" }));
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("account_exists_link_required");
+    // Must NOT have created or mutated a user row.
+    expect(user.create).not.toHaveBeenCalled();
+    expect(user.update).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent: returns the existing active token on repeat calls", async () => {
+    fetchMock.mockResolvedValue({
+      id: 99,
+      login: "returning",
+      name: null,
+      avatar_url: "",
+      email: null,
+    });
+    user.findUnique.mockResolvedValue({
+      id: "user-existing",
+      githubId: "99",
+      email: null,
+    });
+    user.update.mockResolvedValue({ id: "user-existing" });
+    apiToken.findFirst.mockResolvedValue({
+      id: "tok-existing",
+      token: "pf_existing_token_value",
+      userId: "user-existing",
+      revokedAt: null,
+    });
+
+    const res = await POST(makeReq({ githubAccessToken: "valid" }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.apiToken).toBe("pf_existing_token_value");
+    expect(apiToken.create).not.toHaveBeenCalled();
+  });
+
+  it("never leaks the GitHub access-token in response bodies (including errors)", async () => {
+    fetchMock.mockRejectedValue(new GitHubAuthError("401"));
+    const res = await POST(makeReq({ githubAccessToken: "super-secret-value-xyz" }));
+    const body = await res.text();
+    expect(body).not.toContain("super-secret-value-xyz");
+  });
+});


### PR DESCRIPTION
## Summary

Second module to implement the identity-broker contract (agent-tasks already live via PR #176). After project-pilot's GitHub OAuth, it calls this endpoint with the verified access-token and gets back a `pf_*` API token to cache.

## Contract (matches agent-tasks, mirrored by deploy-panel next)

```
POST /api/auth/register-from-project-pilot
Body:     { githubAccessToken: string, githubLogin?: string }
Response: { apiToken, userId, githubLogin }
Errors:   401 unauthorized (bad/mismatched token)
          503 upstream_unavailable (GitHub unreachable)
          409 account_exists_link_required (email collision)
          400 bad_request (malformed body)
```

## Trust model

project-forge does NOT trust project-pilot's claim. Every call re-verifies the token via `GET https://api.github.com/user`. If `githubLogin` is claimed, it must match the verified identity.

## Security: email-collision guard

If a local-auth user already exists with the GitHub email and has no `githubId` yet, registration returns **409 `account_exists_link_required`** rather than silently merging. Otherwise an attacker controlling that email on GitHub could take over the local account. project-pilot should surface this to the user and prompt for explicit local sign-in + link (future task).

## Schema change

- `User.email` + `User.passwordHash` → nullable (OAuth users have no password and may hide email).
- New `User.githubId @unique` + `User.githubLogin` columns.
- SQLite — `prisma db push` handles the table rebuild.

Also fixed: NextAuth Credentials provider now guards on `!user.passwordHash` to avoid leaking account existence for OAuth-only users, and the GitHub signIn callback now writes `passwordHash: null` instead of `""` so we have a single sentinel.

## Idempotency

Repeat calls for the same GitHub identity return the existing active `pf_` token tagged `name: "project-pilot"` rather than minting a new one. Revoked tokens are filtered out so a fresh one is issued after revocation.

## Tests

`npx vitest run` — 29/29 passing (8 new in `tests/integration/register-from-project-pilot.test.ts`):
- 400 missing field
- 401 GitHub auth failure
- 503 GitHub unreachable
- 401 login mismatch
- 200 new user provisioned
- 200 idempotent repeat
- 409 email-collision guard
- no access-token leaked in any response body

## Note

This task was originally filed under the `scaffoldkit` agent-tasks project (25b36611); the code correctly lives in the `project-forge` repo — scaffoldkit is the downstream lib, project-forge is the web service that exposes the HTTP API.

## Test plan

- [x] Typecheck + vitest clean
- [ ] After deploy, project-pilot's OAuth callback should register at project-forge successfully (`project-forge` slot in the `ServiceCredential` table populates).