### PR TITLE
fix(deploy): sibling-relative compose paths (unblocks agent-relay builds)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,12 @@ services:
       PLANFORGE_URL: http://planforge:8223
       PLANFORGE_SERVICE_TOKEN: ${PLANFORGE_SERVICE_TOKEN}
     volumes:
-      - /root/git/agent-planforge:/tools/agent-planforge:ro
-      - /root/git/scaffoldkit:/tools/scaffoldkit:ro
+      # Sibling-relative paths: work both in local dev (git clones live
+      # side-by-side under ~/git) and via agent-relay on prod (the relay
+      # container mounts /root/git at /apps, so relative paths resolve
+      # correctly; absolute /root/git/* paths would fail inside the relay).
+      - ../agent-planforge:/tools/agent-planforge:ro
+      - ../scaffoldkit:/tools/scaffoldkit:ro
       - forge_tmp:/tmp/project-forge
       - forge_db:/data
     labels:
@@ -53,7 +57,10 @@ services:
   # `planforge:8223`. Anything outside the network is invisible to it.
   planforge:
     build:
-      context: /root/git/agent-planforge
+      # Sibling path. See rationale on the `app` service volumes above —
+      # absolute /root/git/* doesn't resolve inside agent-relay's container
+      # where the host's /root/git is mounted at /apps.
+      context: ../agent-planforge
       dockerfile: server/Dockerfile
     environment:
       PLANFORGE_SERVICE_TOKEN: ${PLANFORGE_SERVICE_TOKEN}


### PR DESCRIPTION
## Problem

Every deploy-panel deploy of project-forge since PR #44 has failed with:

```
unable to prepare context: path "/root/git/agent-planforge" not found
```

Rollback fails with the same error, so the status gets stuck.

## Root cause

agent-relay bind-mounts the host's `/root/git` at `/apps` (so its container sees `/apps/agent-planforge`, not `/root/git/agent-planforge`). Compose context-packaging happens CLI-side, inside the relay container — absolute `/root/git/*` paths can't resolve. The running `project-forge-planforge-1` container still exists from a prior host-side build; new builds all fail.

## Fix

Use sibling-relative paths (`../agent-planforge`, `../scaffoldkit`) in `docker-compose.yml`. Relative paths are resolved from the compose file's directory, so they work:

- **Local dev:** `~/git/project-forge/../agent-planforge` → `~/git/agent-planforge` ✓
- **agent-relay:** `/apps/project-forge/../agent-planforge` → `/apps/agent-planforge` ✓

Applied to both the `app` volume mounts and the `planforge` build context.

## Test plan

- [ ] Deploy after merge — compose build should reach the planforge image without "path not found"
- [ ] PR #47 (identity-broker endpoint) can then deploy end-to-end