### PR TITLE
fix(deploy): compose sibling-path for build context, host-path for vo…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,12 +21,18 @@ services:
       PLANFORGE_URL: http://planforge:8223
       PLANFORGE_SERVICE_TOKEN: ${PLANFORGE_SERVICE_TOKEN}
     volumes:
-      # Sibling-relative paths: work both in local dev (git clones live
-      # side-by-side under ~/git) and via agent-relay on prod (the relay
-      # container mounts /root/git at /apps, so relative paths resolve
-      # correctly; absolute /root/git/* paths would fail inside the relay).
-      - ../agent-planforge:/tools/agent-planforge:ro
-      - ../scaffoldkit:/tools/scaffoldkit:ro
+      # Bind-mount sources are resolved by the docker DAEMON against the
+      # HOST filesystem (unlike build contexts, which are packaged by the
+      # compose CLI and follow the CLI's own view). On prod the daemon
+      # runs on the host where these absolute paths exist; in agent-relay
+      # the compose CLI never touches these — it only hands the sources
+      # to the daemon by name.
+      #
+      # Local dev note: if you clone agent-planforge/scaffoldkit somewhere
+      # other than /root/git, override these two lines via
+      # docker-compose.override.yml.
+      - /root/git/agent-planforge:/tools/agent-planforge:ro
+      - /root/git/scaffoldkit:/tools/scaffoldkit:ro
       - forge_tmp:/tmp/project-forge
       - forge_db:/data
     labels:


### PR DESCRIPTION
…lumes

agent-relay bind-mounts the host's /root/git at /apps. Docker compose treats these two differently:

- Build `context:` is packaged by the compose CLI. The CLI runs inside the agent-relay container, so it only sees /apps/* — absolute /root/git/* paths don't resolve for contexts, they fail with "unable to prepare context: path not found". Relative paths like ../agent-planforge work from the compose file's dir (/apps/project-forge).

- Bind-mount sources are resolved by the docker DAEMON against the HOST filesystem. The daemon runs on the host, so /root/git/* DOES exist there. Relative paths in the compose file are resolved by the CLI relative to /apps/project-forge and handed to the daemon as /apps/* — but the daemon doesn't see /apps on the host, so the mount silently becomes an empty directory (docker's default for missing bind-mount sources), and app containers start with empty /tools/*.

Using different paths for context vs volumes is ugly but correct for this bind-mount-heavy deploy topology:
  context: ../agent-planforge   (CLI view)
  volumes: /root/git/...         (daemon view)