### PR TITLE
feat(auth): optional GitHub-login allowlist on broker registration

### DIFF
--- a/app/api/auth/register-from-project-pilot/route.ts
+++ b/app/api/auth/register-from-project-pilot/route.ts
@@ -90,6 +90,28 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  // Optional stop-gap allowlist, mirrored from deploy-panel (#57) and
+  // agent-tasks (#178). Empty/unset env var = back-compat accept-any;
+  // set to a comma-separated list to gate broker registration to those
+  // GitHub logins. Becomes optional product policy once per-user data
+  // isolation is in place.
+  const allowedGitHubLogins = (process.env.ALLOWED_GITHUB_LOGINS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (
+    allowedGitHubLogins.length > 0 &&
+    !allowedGitHubLogins.includes(githubUser.login)
+  ) {
+    return NextResponse.json(
+      {
+        error: "forbidden_github_login",
+        message: "This GitHub login is not permitted on this project-forge instance",
+      },
+      { status: 403 },
+    );
+  }
+
   const githubId = String(githubUser.id);
   const githubEmail = githubUser.email?.toLowerCase() ?? null;
 

--- a/tests/integration/register-from-project-pilot.test.ts
+++ b/tests/integration/register-from-project-pilot.test.ts
@@ -167,6 +167,51 @@ describe("POST /api/auth/register-from-project-pilot", () => {
     expect(apiToken.create).not.toHaveBeenCalled();
   });
 
+  it("403 when ALLOWED_GITHUB_LOGINS is set and login is not in list", async () => {
+    process.env.ALLOWED_GITHUB_LOGINS = "authorized-user";
+    try {
+      fetchMock.mockResolvedValue({
+        id: 77,
+        login: "stranger",
+        name: null,
+        avatar_url: "",
+        email: null,
+      });
+
+      const res = await POST(makeReq({ githubAccessToken: "valid" }));
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe("forbidden_github_login");
+      expect(user.create).not.toHaveBeenCalled();
+      expect(user.update).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.ALLOWED_GITHUB_LOGINS;
+    }
+  });
+
+  it("accepts when ALLOWED_GITHUB_LOGINS is set and login matches", async () => {
+    process.env.ALLOWED_GITHUB_LOGINS = "ok-user";
+    try {
+      fetchMock.mockResolvedValue({
+        id: 11,
+        login: "ok-user",
+        name: null,
+        avatar_url: "",
+        email: null,
+      });
+      user.findUnique.mockResolvedValue(null);
+      user.create.mockResolvedValue({ id: "user-ok", githubLogin: "ok-user" });
+      apiToken.findFirst.mockResolvedValue(null);
+
+      const res = await POST(makeReq({ githubAccessToken: "valid" }));
+
+      expect(res.status).toBe(200);
+    } finally {
+      delete process.env.ALLOWED_GITHUB_LOGINS;
+    }
+  });
+
   it("never leaks the GitHub access-token in response bodies (including errors)", async () => {
     fetchMock.mockRejectedValue(new GitHubAuthError("401"));
     const res = await POST(makeReq({ githubAccessToken: "super-secret-value-xyz" }));


### PR DESCRIPTION
## Summary

Sibling of deploy-panel #57 and agent-tasks #178. Stop-gap: gate `register-from-project-pilot` by an optional `ALLOWED_GITHUB_LOGINS` env var until per-user isolation is audited (tracked in task `cbb5d917`).

## Behavior

- Empty/unset = accept any verified login (back-compat).
- Non-empty comma-separated list = verified login must be in it, else 403 `forbidden_github_login`.

## Rollout

Set `ALLOWED_GITHUB_LOGINS=LanNguyenSi` in prod `.env` alongside the sibling module rollouts.

## Tests

10/10 passing (+2 around this change).