### PR TITLE
test(security): pin per-user isolation invariants on v1 endpoints

### DIFF
--- a/tests/integration/cross-user-isolation.test.ts
+++ b/tests/integration/cross-user-isolation.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/db")>("@/lib/db");
+  return {
+    ...actual,
+    prisma: {
+      usageLog: {
+        findMany: vi.fn(),
+        findFirst: vi.fn(),
+        count: vi.fn(),
+        update: vi.fn(),
+        create: vi.fn(),
+      },
+      apiToken: { findUnique: vi.fn(), update: vi.fn() },
+    },
+    validateApiToken: vi.fn(),
+    checkRateLimit: vi.fn().mockResolvedValue({ allowed: true, used: 0 }),
+  };
+});
+
+import { prisma, validateApiToken } from "@/lib/db";
+import { GET as listProjects, DELETE as deleteProject } from "@/app/api/v1/projects/route";
+import { GET as preview } from "@/app/api/v1/preview/route";
+import { POST as publish } from "@/app/api/v1/publish/route";
+import { NextRequest } from "next/server";
+import * as fs from "fs/promises";
+import * as path from "path";
+
+const mValidateToken = vi.mocked(validateApiToken);
+const usageLog = prisma.usageLog as unknown as {
+  findMany: ReturnType<typeof vi.fn>;
+  findFirst: ReturnType<typeof vi.fn>;
+  count: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+};
+
+interface RequestOpts {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+function userARequest(url: string, init?: RequestOpts): NextRequest {
+  return new NextRequest(url, {
+    ...init,
+    headers: { "X-API-Key": "pf_user_a_token", ...(init?.headers ?? {}) },
+  });
+}
+
+function stubToken(userId: string) {
+  return {
+    id: `tok-${userId}`,
+    token: `pf_${userId}_token`,
+    userId,
+    name: "test",
+    revokedAt: null,
+    lastUsedAt: null,
+    createdAt: new Date(),
+    user: {
+      id: userId,
+      email: `${userId}@example.com`,
+      passwordHash: null,
+      githubId: userId,
+      githubLogin: userId,
+      githubPat: null,
+      githubOwner: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  };
+}
+
+describe("cross-user isolation — v1 API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mValidateToken.mockImplementation(async (token: string) => {
+      if (token === "pf_user_a_token") return stubToken("user-a") as never;
+      if (token === "pf_user_b_token") return stubToken("user-b") as never;
+      return null;
+    });
+  });
+
+  it("GET /api/v1/projects scopes the query to the caller's userId", async () => {
+    usageLog.findMany.mockResolvedValue([]);
+    usageLog.count.mockResolvedValue(0);
+
+    await listProjects(userARequest("http://test/api/v1/projects"));
+
+    // Invariant: the where clause passed to Prisma MUST carry the authed user id.
+    const findManyArg = usageLog.findMany.mock.calls[0]?.[0];
+    expect(findManyArg?.where?.userId).toBe("user-a");
+
+    const countArg = usageLog.count.mock.calls[0]?.[0];
+    expect(countArg?.where?.userId).toBe("user-a");
+  });
+
+  it("DELETE /api/v1/projects 404s when user A targets user B's row", async () => {
+    // findFirst with { id, userId: 'user-a' } returns null because the row
+    // is owned by user-b. The route must not fall back to updating without
+    // the userId guard.
+    usageLog.findFirst.mockResolvedValue(null);
+
+    const res = await deleteProject(
+      userARequest("http://test/api/v1/projects?id=row-owned-by-b", { method: "DELETE" }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(usageLog.update).not.toHaveBeenCalled();
+
+    // Verify the where clause carried BOTH id and userId — this is the guard.
+    const findFirstArg = usageLog.findFirst.mock.calls[0]?.[0];
+    expect(findFirstArg?.where?.userId).toBe("user-a");
+  });
+
+  it("GET /api/v1/preview — user A gets 404 on user B's sessionId (not leaked as 403)", async () => {
+    // The route intentionally returns 404 (not 403) on cross-user access so
+    // an attacker can't probe for sessionId existence. What we MUST verify:
+    // no preview data is ever returned across user boundaries.
+    const tempRoot = process.env.FORGE_TEMP_DIR ?? "/tmp/project-forge";
+    const sessionId = "11111111-1111-1111-1111-111111111111";
+    const sessionDir = path.join(tempRoot, sessionId);
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sessionDir, ".forge-meta.json"),
+      JSON.stringify({
+        userId: "user-b",
+        sessionId,
+        createdAt: new Date().toISOString(),
+        preview: { leakedField: "should-not-appear" },
+      }),
+    );
+
+    try {
+      const res = await preview(
+        userARequest(`http://test/api/v1/preview?sessionId=${sessionId}`),
+      );
+      expect(res.status).toBe(404);
+      const body = await res.text();
+      expect(body).not.toContain("leakedField");
+      expect(body).not.toContain("should-not-appear");
+    } finally {
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  it("POST /api/v1/publish — user A gets 404 on user B's sessionId (not 403) and does NOT publish", async () => {
+    const tempRoot = process.env.FORGE_TEMP_DIR ?? "/tmp/project-forge";
+    const sessionId = "22222222-2222-2222-2222-222222222222";
+    const sessionDir = path.join(tempRoot, sessionId);
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sessionDir, ".forge-meta.json"),
+      JSON.stringify({
+        userId: "user-b",
+        sessionId,
+        createdAt: new Date().toISOString(),
+        preview: {},
+      }),
+    );
+
+    try {
+      const res = await publish(
+        userARequest("http://test/api/v1/publish", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sessionId }),
+        }),
+      );
+      expect(res.status).toBe(404);
+      // Hard invariant: no UsageLog row MAY be created for user A via a
+      // sessionId owned by user B.
+      expect(prisma.usageLog.create).not.toHaveBeenCalled?.();
+    } finally {
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Audit outcome

Thorough sweep of every route that touches user-owned data:

| Route | Auth | Scoping | Verdict |
|---|---|---|---|
| GET /api/v1/projects | X-API-Key | `where: { userId: tokenRecord.userId, ... }` | ✓ |
| DELETE /api/v1/projects | X-API-Key | `findFirst({ id, userId })` guard before update | ✓ |
| POST /api/v1/projects | X-API-Key | Stamps `userId` on create | ✓ |
| POST /api/v1/generate | X-API-Key | Writes `userId` into `.forge-meta.json` | ✓ |
| GET /api/v1/preview | X-API-Key | `meta.userId !== tokenRecord.userId` → 404 | ✓ |
| POST /api/v1/publish | X-API-Key | Same 404 guard, stamps userId on create | ✓ |
| /api/dashboard/* | Session | Self-scoped via session.user.id | ✓ |
| /api/ai-assist, /api/planforge | Public | Stateless, no DB | ✓ |

**Isolation is already correct.** The real gap is test coverage — no regression net existed to stop a future refactor from silently weakening the guards.

## What this PR ships

New `tests/integration/cross-user-isolation.test.ts` — 4 tests, one per critical invariant:

1. `GET /api/v1/projects` — the Prisma `where` clause must carry `userId` from the token (both `findMany` and `count`).
2. `DELETE /api/v1/projects` — user A targeting user B's row hits `findFirst({ id, userId: 'user-a' })` which returns null; the route returns 404 and `update` is never called.
3. `GET /api/v1/preview` — cross-user access returns **404 intentionally** (hides session existence). The test pins this and asserts no preview data leaks in the response body.
4. `POST /api/v1/publish` — same 404 on cross-user. Test also asserts `prisma.usageLog.create` was NOT called — the strong invariant that user A cannot publish against user B's sessionId.

## Tests

`npx vitest run` — 35/35 passing (4 new, all pre-existing pass).

## Non-goals (for future follow-up)

- Auth routes (`/api/auth/*`) — covered in their own test file.
- Multi-user team sharing / cross-account collaboration — out of scope.
- Admin bypass — project-forge has no admin token, so N/A.