### PR TITLE
feat(ui): attachments v0.1c — single-file upload in create flow

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -36,11 +36,17 @@ export async function POST(req: NextRequest) {
     const tempDir = path.join(TEMP_ROOT, sessionId);
     await fs.mkdir(tempDir, { recursive: true });
 
+    // Attachments are a service-layer concern in planforge's contract —
+    // they ride alongside `input` in the POST body, not inside it. Peel
+    // them off here so buildPlanforgeInput sees only the CLI-input shape,
+    // then forward them as a sibling field to runPlanforgeViaHttp.
+    // Back-compat: absent/empty → pipeline sees the pre-v0.1 shape.
+    const { attachments, ...planforgeInputSource } = input;
     // Plan + scaffold via the planforge HTTP service. The response tarball
     // contains both planning artifacts and the scaffolded project tree;
     // they're extracted directly into tempDir so downstream code reads
     // from the same layout the legacy subprocess produced.
-    const { planforgeInput } = await buildPlanforgeInput(input);
+    const { planforgeInput } = await buildPlanforgeInput(planforgeInputSource);
     const baseUrl = process.env.PLANFORGE_URL;
     const token = process.env.PLANFORGE_SERVICE_TOKEN;
     if (!baseUrl || !token) {
@@ -52,6 +58,12 @@ export async function POST(req: NextRequest) {
       baseUrl,
       token,
       input: planforgeInput,
+      // Only send `attachments` to planforge when the caller supplied some.
+      // An empty array would still satisfy the server's shape validator,
+      // but sending it on every request makes logs and packet captures
+      // noisier without adding information — preserve the pre-v0.1 body
+      // for the no-attachments case.
+      ...(attachments && attachments.length > 0 ? { attachments } : {}),
       outdir: tempDir,
       timeoutMs: GENERATION_TIMEOUT_MS,
     });

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -1,8 +1,30 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import type { ProjectInput } from "@/lib/types";
+import type { ProjectInput, Attachment } from "@/lib/types";
 import { Button, Input, Textarea, Label, Alert } from "@/components/ui/primitives";
+
+/**
+ * Matches planforge's 50_000-char total-inlineText cap (v0.1b). We enforce
+ * it client-side too so oversized uploads fail instantly in the UI instead
+ * of making the round-trip just to be rejected. v0.1c only supports a
+ * single file, so per-file === total.
+ */
+const MAX_ATTACHMENT_CHARS = 50_000;
+
+/**
+ * v0.1c text-tier only. `.adoc` is asciidoc — the CLI prompt templates
+ * read the augmented summary as plain text so any of these extensions is
+ * "good enough" to pass through unmodified. Binary tiers (pdf/png/svg/
+ * drawio/puml) land in v0.2.
+ */
+const ACCEPTED_EXTENSIONS = [".md", ".txt", ".adoc"] as const;
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  ".md": "text/markdown",
+  ".txt": "text/plain",
+  ".adoc": "text/asciidoc",
+};
 
 interface ProjectFormProps {
   onSubmit: (input: ProjectInput) => void;
@@ -38,6 +60,56 @@ export function ProjectForm({ onSubmit, isLoading = false, initialValues }: Proj
   }, [initialValues]);
 
   const [formError, setFormError] = useState<string | null>(null);
+
+  // Attachments state — v0.1c keeps it minimal: one optional text-tier
+  // file. `null` means "no attachment selected" and no `attachments`
+  // field is included in the submit payload (preserves pre-v0.1 wire
+  // shape for the no-attachment case).
+  const [attachment, setAttachment] = useState<Attachment | null>(null);
+  const [attachmentError, setAttachmentError] = useState<string | null>(null);
+
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    setAttachmentError(null);
+    const file = e.target.files?.[0];
+    if (!file) return;
+    // Reset the <input> so selecting the same file twice (e.g. after a
+    // removal) still fires onChange.
+    e.target.value = "";
+
+    const lowerName = file.name.toLowerCase();
+    const ext = ACCEPTED_EXTENSIONS.find((x) => lowerName.endsWith(x));
+    if (!ext) {
+      setAttachmentError(
+        `Unsupported file type. Accepted: ${ACCEPTED_EXTENSIONS.join(", ")}`,
+      );
+      return;
+    }
+
+    try {
+      const text = await file.text();
+      if (text.length > MAX_ATTACHMENT_CHARS) {
+        setAttachmentError(
+          `File is ${text.length.toLocaleString()} chars; limit is ${MAX_ATTACHMENT_CHARS.toLocaleString()}. Split or shorten it.`,
+        );
+        return;
+      }
+      setAttachment({
+        name: file.name,
+        mimeType: MIME_BY_EXTENSION[ext],
+        tier: "text",
+        inlineText: text,
+      });
+    } catch (err) {
+      setAttachmentError(
+        `Could not read file: ${err instanceof Error ? err.message : "unknown error"}`,
+      );
+    }
+  };
+
+  const handleRemoveAttachment = () => {
+    setAttachment(null);
+    setAttachmentError(null);
+  };
 
   const handleMagicFill = async () => {
     if (!magicPrompt.trim()) return;
@@ -88,6 +160,10 @@ export function ProjectForm({ onSubmit, isLoading = false, initialValues }: Proj
       features,
       constraints: constraintsText.split("\n").map((c) => c.trim()).filter(Boolean),
       targetUsers,
+      // Only include `attachments` when the user actually selected a file;
+      // the route and planforge both special-case absence to preserve the
+      // pre-v0.1 wire shape.
+      ...(attachment ? { attachments: [attachment] } : {}),
     });
   };
 
@@ -188,6 +264,59 @@ export function ProjectForm({ onSubmit, isLoading = false, initialValues }: Proj
           placeholder={"developers\ninternal team"}
           rows={2}
         />
+      </div>
+
+      <div>
+        <Label hint="(optional, arc42/RFC/notes: .md, .txt, .adoc; 50k char limit)">
+          Planning Context
+        </Label>
+        {attachment ? (
+          <div className="flex items-center justify-between rounded-md bg-gray-900/60 border border-gray-800 px-3 py-2 text-sm">
+            <div className="flex min-w-0 items-center gap-2">
+              <svg
+                className="w-4 h-4 text-gray-400 shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+                />
+              </svg>
+              <span className="truncate font-mono text-gray-300" title={attachment.name}>
+                {attachment.name}
+              </span>
+              <span className="text-xs text-gray-500 shrink-0">
+                {(attachment.inlineText?.length ?? 0).toLocaleString()} chars
+              </span>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleRemoveAttachment}
+              disabled={isLoading}
+              aria-label={`Remove attachment ${attachment.name}`}
+            >
+              Remove
+            </Button>
+          </div>
+        ) : (
+          <Input
+            type="file"
+            accept={ACCEPTED_EXTENSIONS.join(",")}
+            onChange={handleFileSelect}
+            disabled={isLoading}
+          />
+        )}
+        {attachmentError && (
+          <p className="mt-2 text-xs text-red-400" role="alert">
+            {attachmentError}
+          </p>
+        )}
       </div>
 
       <Button

--- a/lib/planforge-client.ts
+++ b/lib/planforge-client.ts
@@ -31,6 +31,13 @@ export interface RunPlanforgeOptions {
   token: string;
   /** The planforge input payload — same shape the CLI's `--input` accepts. */
   input: unknown;
+  /**
+   * Optional attachments forwarded as planforge's top-level `attachments`
+   * field (v0.1a contract, text-tier ingest in v0.1b). Kept opaque here
+   * to avoid coupling this client to the Attachment interface's concrete
+   * shape — the server validates and rejects with 400 on malformed entries.
+   */
+  attachments?: unknown[];
   /** Local directory to extract the CLI output into. Must already exist. */
   outdir: string;
   /**
@@ -120,7 +127,16 @@ export async function runPlanforgeViaHttp(
       // pins the intent in the wire format. If a future planforge release
       // flips the default to false, this keeps project-forge's contract
       // stable.
-      body: JSON.stringify({ input: options.input, scaffold: true }),
+      //
+      // `attachments` is only added when present — a caller with no
+      // attachments produces a body identical to the pre-v0.1 shape, so
+      // older planforge deploys that predate the attachments contract
+      // keep working.
+      body: JSON.stringify({
+        input: options.input,
+        scaffold: true,
+        ...(options.attachments !== undefined ? { attachments: options.attachments } : {}),
+      }),
       signal: controller.signal,
     });
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,16 @@
+/**
+ * Mirrors the top-level `attachments` field on planforge's POST /api/generate.
+ * v0.1c carries only text-tier entries with inlineText; diagram / structured
+ * tiers are part of the contract but not produced by this UI yet.
+ */
+export interface Attachment {
+  name: string;
+  mimeType: string;
+  tier: "text" | "diagram" | "structured";
+  inlineText?: string;
+  contentRef?: string;
+}
+
 // Input from the project creation form
 export interface ProjectInput {
   projectName: string;
@@ -5,6 +18,14 @@ export interface ProjectInput {
   features: string[];
   constraints: string[];
   targetUsers?: string[];
+  /**
+   * Optional attachments (arc42 docs, RFCs, etc.) submitted alongside the
+   * intake form. These are a service-layer concern — the /api/generate
+   * route peels them off the body and forwards them to planforge's
+   * top-level `attachments` field; they are NOT forwarded into the
+   * PlanforgePlanningInput the CLI consumes.
+   */
+  attachments?: Attachment[];
 }
 
 // A single task from planforge output


### PR DESCRIPTION
## Summary

Slice 3 of 3 for the attachments feature. Companion to agent-planforge v0.1a (PR #64) + v0.1b (PR #65), both merged.

- Extends `ProjectInput` with optional `attachments?: Attachment[]`
- `ProjectForm` gets a text-tier single-file picker (`.md` / `.txt` / `.adoc`) with filename + char-count preview and a Remove button. Enforces the 50k char cap client-side so oversized uploads fail in the UI instead of making the round-trip
- `/api/generate/route.ts` peels attachments off the body and forwards them as a sibling field to `runPlanforgeViaHttp` — `buildPlanforgeInput` keeps seeing only the CLI-input shape (attachment content doesn't leak into the AI enrichment prompt either)
- `lib/planforge-client.ts` only includes `attachments` in the wire body when present, preserving the pre-v0.1 shape for the no-attachment case

## Out of scope (all v0.2)

- Multi-file / drag&drop
- Binary / diagram tier (.pdf, .png, .svg, .drawio, .puml)
- Storage / blob refs
- Content preview in the UI
- Traceability display on the generated plan
- Non-UTF-8 file encoding handling

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 41/41 pass
- [x] `npm run build` clean
- [x] Rigorous review subagent: READY TO MERGE, no blockers
- [ ] Post-deploy smoke: upload an arc42 `.md`, generate project, verify plan references the attached architecture (joint smoke with planforge v0.1b)
- [ ] Post-deploy smoke: remove attachment before submit → verify identical behaviour to pre-v0.1

Follow-ups from review noted for v0.2: UTF-8-only decode silently tolerates mojibake; empty-file selection is a no-op; no content preview; `/api/v1/generate` + `/api/v1/projects` need the same destructure pattern when they gain attachments support.