### PR TITLE
feat(ai): thread attachments into enrichIntake so the LLM actually sees them

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -38,15 +38,18 @@ export async function POST(req: NextRequest) {
 
     // Attachments are a service-layer concern in planforge's contract —
     // they ride alongside `input` in the POST body, not inside it. Peel
-    // them off here so buildPlanforgeInput sees only the CLI-input shape,
-    // then forward them as a sibling field to runPlanforgeViaHttp.
+    // them off the ProjectInput so the rest of the planforge-side shape
+    // (`planforgeInputSource`) stays lean, but **pass them as a sibling
+    // arg into buildPlanforgeInput** so the AI enrichment step gets
+    // visibility on uploaded arc42/RFC/charter content — without that,
+    // v0.1c attachments never reached the LLM (only the heuristic CLI).
     // Back-compat: absent/empty → pipeline sees the pre-v0.1 shape.
     const { attachments, ...planforgeInputSource } = input;
     // Plan + scaffold via the planforge HTTP service. The response tarball
     // contains both planning artifacts and the scaffolded project tree;
     // they're extracted directly into tempDir so downstream code reads
     // from the same layout the legacy subprocess produced.
-    const { planforgeInput } = await buildPlanforgeInput(planforgeInputSource);
+    const { planforgeInput } = await buildPlanforgeInput(planforgeInputSource, attachments);
     const baseUrl = process.env.PLANFORGE_URL;
     const token = process.env.PLANFORGE_SERVICE_TOKEN;
     if (!baseUrl || !token) {

--- a/lib/planforge-orchestrator.ts
+++ b/lib/planforge-orchestrator.ts
@@ -1,4 +1,4 @@
-import type { ProjectInput } from "@/lib/types";
+import type { ProjectInput, Attachment } from "@/lib/types";
 import { getAiCapabilities, generateStructuredJson, type AiProviderName } from "@/lib/ai-provider";
 
 export interface PlanforgePlanningInput {
@@ -56,7 +56,8 @@ Rules:
 - Be conservative. If something is unclear, prefer openQuestions over inventing requirements.
 - Only infer plannerProfile or dataSensitivity when there is a strong signal.
 - Use short concrete strings, not paragraphs.
-- If no enrichment is justified, return {}.`;
+- If no enrichment is justified, return {}.
+- If the user supplied \`additionalContext\` (uploaded arc42, RFCs, charters, prior ADRs), treat it as primary evidence for architectural decisions. Reflect its named integrations (databases, auth providers, queues), non-functional requirements (performance, compliance), data-sensitivity signals (PII, PHI, regulatory language), and enterprise requirements in the output. Prefer facts stated in additionalContext over speculation from the intake form alone.`;
 
 function uniqueStrings(values: string[] | undefined): string[] | undefined {
   if (!values || values.length === 0) {
@@ -121,14 +122,39 @@ function mergePlanforgeInput(
   };
 }
 
+/**
+ * Shape attachments pass into the enrichment prompt. Only `text`-tier
+ * entries with non-empty `inlineText` contribute — other tiers are
+ * shape-validated at the planforge service boundary but are no-ops
+ * here until later slices add vision/structured parsing.
+ */
+function attachmentsForPrompt(
+  attachments: Attachment[] | undefined,
+): Array<{ name: string; inlineText: string }> {
+  if (!attachments || attachments.length === 0) return [];
+  const out: Array<{ name: string; inlineText: string }> = [];
+  for (const a of attachments) {
+    if (a.tier !== "text") continue;
+    if (typeof a.inlineText !== "string" || a.inlineText.length === 0) continue;
+    out.push({ name: a.name, inlineText: a.inlineText });
+  }
+  return out;
+}
+
 async function enrichIntake(
   input: ProjectInput,
-  base: PlanforgePlanningInput
+  base: PlanforgePlanningInput,
+  attachments?: Attachment[]
 ): Promise<{ enrichment: IntakeEnrichment; provider: AiProviderName; model: string }> {
+  const additionalContext = attachmentsForPrompt(attachments);
   const userPrompt = JSON.stringify(
     {
       projectInput: input,
       currentPlanforgeInput: base,
+      // Only include `additionalContext` when the user actually uploaded
+      // something. Keeps the no-attachment call byte-identical to the
+      // pre-v0.1d path so cached completions and test fixtures don't drift.
+      ...(additionalContext.length > 0 ? { additionalContext } : {}),
     },
     null,
     2
@@ -147,7 +173,10 @@ async function enrichIntake(
   };
 }
 
-export async function buildPlanforgeInput(input: ProjectInput): Promise<{
+export async function buildPlanforgeInput(
+  input: ProjectInput,
+  attachments?: Attachment[]
+): Promise<{
   planforgeInput: PlanforgePlanningInput;
   orchestration: PlanforgeOrchestrationMetadata;
 }> {
@@ -167,7 +196,7 @@ export async function buildPlanforgeInput(input: ProjectInput): Promise<{
   }
 
   try {
-    const { enrichment, provider, model } = await enrichIntake(input, base);
+    const { enrichment, provider, model } = await enrichIntake(input, base, attachments);
     return {
       planforgeInput: mergePlanforgeInput(base, enrichment),
       orchestration: {

--- a/tests/integration/planforge-orchestrator.test.ts
+++ b/tests/integration/planforge-orchestrator.test.ts
@@ -68,4 +68,138 @@ describe("planforge intake orchestration", () => {
       "Should the first release support SSO?",
     ]);
   });
+
+  it("forwards text-tier attachments into the enrichment user prompt", async () => {
+    const generateMock = vi.fn(async () => ({
+      provider: "local" as const,
+      model: "qwen-local",
+      data: { dataSensitivity: "regulated" as const },
+    }));
+    vi.doMock("@/lib/ai-provider", () => ({
+      getAiCapabilities: () => ({
+        enabled: true,
+        provider: "local",
+        model: "qwen-local",
+        features: { magicFill: true, intakeEnrichment: true },
+      }),
+      generateStructuredJson: generateMock,
+    }));
+
+    const { buildPlanforgeInput } = await import("../../lib/planforge-orchestrator");
+
+    await buildPlanforgeInput(
+      {
+        projectName: "demo-app",
+        summary: "An internal portal.",
+        features: ["dashboard"],
+        constraints: [],
+        targetUsers: ["staff"],
+      },
+      [
+        {
+          name: "arc42-snippet.md",
+          mimeType: "text/markdown",
+          tier: "text",
+          inlineText: "## Compliance\n\nMust comply with HIPAA for patient data.",
+        },
+      ]
+    );
+
+    expect(generateMock).toHaveBeenCalledTimes(1);
+    const [systemPrompt, userPrompt] = generateMock.mock.calls[0] as unknown as [string, string];
+
+    // System prompt now instructs the model on additionalContext semantics.
+    expect(systemPrompt).toMatch(/additionalContext/);
+    expect(systemPrompt).toMatch(/arc42|RFC|charter/i);
+
+    // User prompt carries the attachment under a stable key so the model
+    // can latch onto it without prompt-position guessing.
+    const parsed = JSON.parse(userPrompt) as Record<string, unknown>;
+    expect(parsed).toHaveProperty("additionalContext");
+    expect(parsed.additionalContext).toEqual([
+      {
+        name: "arc42-snippet.md",
+        inlineText: "## Compliance\n\nMust comply with HIPAA for patient data.",
+      },
+    ]);
+  });
+
+  it("omits additionalContext from the user prompt when no attachments are present (back-compat)", async () => {
+    const generateMock = vi.fn(async () => ({
+      provider: "local" as const,
+      model: "qwen-local",
+      data: {},
+    }));
+    vi.doMock("@/lib/ai-provider", () => ({
+      getAiCapabilities: () => ({
+        enabled: true,
+        provider: "local",
+        model: "qwen-local",
+        features: { magicFill: true, intakeEnrichment: true },
+      }),
+      generateStructuredJson: generateMock,
+    }));
+
+    const { buildPlanforgeInput } = await import("../../lib/planforge-orchestrator");
+
+    await buildPlanforgeInput({
+      projectName: "demo-app",
+      summary: "An internal portal.",
+      features: ["dashboard"],
+      constraints: [],
+      targetUsers: ["staff"],
+    });
+
+    const [, userPrompt] = generateMock.mock.calls[0] as unknown as [string, string];
+    // Asserting absence (not just falsy) keeps the no-attachment user
+    // prompt byte-identical to the pre-v0.1d shape — important if anyone
+    // is caching prompt completions or pinning fixtures.
+    const parsed = JSON.parse(userPrompt) as Record<string, unknown>;
+    expect(parsed).not.toHaveProperty("additionalContext");
+  });
+
+  it("ignores diagram/structured tiers and empty inlineText in the prompt build", async () => {
+    const generateMock = vi.fn(async () => ({
+      provider: "local" as const,
+      model: "qwen-local",
+      data: {},
+    }));
+    vi.doMock("@/lib/ai-provider", () => ({
+      getAiCapabilities: () => ({
+        enabled: true,
+        provider: "local",
+        model: "qwen-local",
+        features: { magicFill: true, intakeEnrichment: true },
+      }),
+      generateStructuredJson: generateMock,
+    }));
+
+    const { buildPlanforgeInput } = await import("../../lib/planforge-orchestrator");
+
+    await buildPlanforgeInput(
+      {
+        projectName: "demo",
+        summary: "x",
+        features: ["a"],
+        constraints: [],
+        targetUsers: ["u"],
+      },
+      [
+        // Diagram tier → no-op until v0.2.
+        { name: "x.png", mimeType: "image/png", tier: "diagram" },
+        // Structured tier → no-op until v0.2.
+        { name: "x.drawio", mimeType: "application/vnd.jgraph.mxfile", tier: "structured" },
+        // Text but empty → drop (no signal to add).
+        { name: "empty.md", mimeType: "text/markdown", tier: "text", inlineText: "" },
+        // Text but missing inlineText → drop.
+        { name: "noinline.md", mimeType: "text/markdown", tier: "text" },
+      ]
+    );
+
+    const [, userPrompt] = generateMock.mock.calls[0] as unknown as [string, string];
+    const parsed = JSON.parse(userPrompt) as Record<string, unknown>;
+    // None of the entries qualified, so additionalContext stays absent
+    // — matches the back-compat path above.
+    expect(parsed).not.toHaveProperty("additionalContext");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the smoke-test gap after v0.1a/b/c shipped: attachments attached in the UI but the generated plan looked identical to the no-attachment case.

**Root cause**: the route was peeling `attachments` off BEFORE `buildPlanforgeInput`, so `enrichIntake` (the only real LLM call in the chain) never saw them. The v0.1b planforge-side summary-prepend runs but only feeds heuristic/template code paths.

**Fix**:
- `buildPlanforgeInput(input, attachments?)` — optional second arg
- `enrichIntake` appends `additionalContext: [{name, inlineText}, …]` into the userPrompt JSON (text-tier + non-empty only; diagram/structured shape-valid but no-op)
- `ENRICHMENT_SYSTEM_PROMPT` instructs the model to use additionalContext as primary evidence for NFRs/integrations/data-sensitivity/plannerProfile
- Route stops pre-stripping; passes attachments as sibling arg. Forward-to-planforge peels its own local copy (wire-shape to planforge unchanged)
- No-attachment userPrompt stays byte-identical to pre-v0.1d via conditional spread

3 new tests: with-attachment text present, without stays clean (back-compat), non-text tiers filtered. 44/44 pass, tsc + next build clean.

## Follow-ups from review (out of scope for v0.1d)

- **D1** injection-sentinel wrap for attachment inlineText — lower trust level than Summary field
- **D2** soften "primary evidence" wording so user intake choices aren't silently overridden
- **D3** per-attachment token budget for small-context local models
- **D4** multi-attachment ordering test

Will file as separate tasks.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 44/44
- [x] `npm run build` clean
- [x] Rigorous review subagent: READY TO MERGE
- [ ] Post-deploy: upload an arc42 mentioning "HIPAA" → verify `dataSensitivity: regulated` appears in the enrichment output

Closes agent-tasks `1f7a47a6-3635-4c28-964c-d74fbc08a6bd`.