### PR TITLE
chore(deps): bump postcss to ^8.5.10 (alert #15)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "autoprefixer": "^10.4.0",
         "happy-dom": "^20.8.8",
-        "postcss": "^8.4.0",
+        "postcss": "^8.5.10",
         "prisma": "^5.22.0",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.4.0",
@@ -4200,34 +4200,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -4505,7 +4477,6 @@
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
       "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -37,13 +37,14 @@
     "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.0",
     "happy-dom": "^20.8.8",
-    "postcss": "^8.4.0",
+    "postcss": "^8.5.10",
     "prisma": "^5.22.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.4.0",
     "vitest": "^4.1.1"
   },
   "overrides": {
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #15: postcss <8.5.10 GHSA XSS via unescaped `</style>`.

Follow-up to PR #59 which only addressed uuid; the postcss alert was missed because the dashboard's vulnerability count was outdated at sweep start. `next@15.5.15` transitively bundles `postcss@8.4.31` (the actual vulnerable copy).

- Direct devDep `postcss ^8.4.0 → ^8.5.10`
- Added `postcss ^8.5.10` to existing overrides block (preserves uuid override from PR #59)

After install, all postcss consumers (next, autoprefixer, tailwindcss + plugins, vite) dedupe to `8.5.12 overridden`.

## Test plan

- [x] `next build` clean
- [x] `npm test` 64/64 pass
- [x] `npm ls postcss` shows no <8.5.10 instances