### PR TITLE
docs: add open source surface (CoC, contributing, security, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,42 @@
+name: Bug report
+description: Report a defect in project-forge
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      options:
+        - Next.js UI
+        - API routes
+        - scaffoldkit integration
+        - planforge integration
+        - Prisma schema / migrations
+        - hosted instance (project-forge.opentriologue.ai)
+        - other / unsure
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: Expected vs. actual behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Minimal commands or actions that trigger the bug.
+      render: bash
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit SHA
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      placeholder: "self-hosted, local dev, hosted instance"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/LanNguyenSi/project-forge/blob/main/SECURITY.md
+    about: Please report vulnerabilities privately, not via public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,19 @@
+name: Feature request
+description: Propose a new capability or surface
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: usecase
+    attributes:
+      label: Use case
+      description: What problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- One or two sentences. What changed? -->
+
+## Motivation
+
+<!-- Why this change? Link the issue if applicable. -->
+
+## Test plan
+
+- [ ] `npx prisma generate`
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] For Prisma changes: migration committed alongside schema
+- [ ] Manual smoke check: <!-- command or scenario -->
+
+## Notes for reviewer
+
+<!-- Anything non-obvious: tradeoffs, follow-ups, open questions. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+By participating, you agree to uphold its standards.
+
+## Reporting
+
+Report incidents to **contact@lan-nguyen-si.de**. Reports are kept confidential.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to project-forge
+
+Thanks for your interest. project-forge is a web UI for creating AI-toolchain projects with planforge + scaffoldkit. Live: [project-forge.opentriologue.ai](https://project-forge.opentriologue.ai).
+
+## Issues
+
+- Bug reports: include repro steps, expected vs. actual, the affected surface (Next.js UI, API route, scaffoldkit integration, planforge integration, Prisma).
+- Feature requests: describe the use case before the proposed shape.
+
+## Pull Requests
+
+1. Fork, branch off `main` (e.g. `feat/<scope>`, `fix/<scope>`).
+2. Keep changes scoped where possible.
+3. Run the local checks:
+
+   ```bash
+   npm install
+   npx prisma generate
+   npm run build
+   npm test
+   ```
+
+4. For Prisma schema changes, generate a migration and check it in alongside the schema edit.
+5. Open the PR with a clear summary, motivation, and test plan.
+
+## Dev Setup
+
+```bash
+git clone https://github.com/LanNguyenSi/project-forge.git
+cd project-forge
+npm install
+docker compose up -d   # Postgres
+npx prisma migrate dev
+npm run dev
+```
+
+## Style
+
+Match the surrounding code. Prefer small, reviewable diffs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+Active development is on `main`. Hosted instance: [project-forge.opentriologue.ai](https://project-forge.opentriologue.ai), tracks `main`.
+
+project-forge generates project scaffolds and pushes to GitHub on behalf of users. Vulnerabilities (auth bypass, GitHub-token leak, scaffold-injection, push-target manipulation) are treated as serious.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security reports.
+
+Email **contact@lan-nguyen-si.de** with:
+
+- Affected surface
+- Reproduction steps or proof-of-concept
+- Impact assessment
+
+You will get an acknowledgement within 72 hours and an initial assessment within 7 days. A fix timeline depends on severity and complexity, communicated in the assessment.


### PR DESCRIPTION
## Summary

LICENSE already shipped. Adds the rest:

- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1, by reference)
- `CONTRIBUTING.md` (issue + PR flow, Prisma generate prereq + migration reminder)
- `SECURITY.md` (GitHub-token / push-target framing; contact@lan-nguyen-si.de)
- `.github/ISSUE_TEMPLATE/bug_report.yml`, `feature_request.yml`, `config.yml`
- `.github/pull_request_template.md`

## Motivation

Closes the open-source-checklist task for project-forge.

## Test plan

- [x] All 7 new files render in GitHub preview
- [x] All 3 issue YAMLs parse via `yaml.safe_load`
- [x] slop-detector clean
- [x] No em-dashes
- [x] No source code touched