### PR TITLE
feat: mirror planforge input_unreadable skipped value

### DIFF
--- a/lib/planforge-client.ts
+++ b/lib/planforge-client.ts
@@ -54,7 +54,23 @@ export interface ScaffoldkitResult {
   invoked: boolean;
   exitCode?: number;
   stderr?: string;
-  skipped?: "no_input" | "opt_out" | "not_installed";
+  /**
+   * Reason scaffoldkit did not run. Mirrors agent-planforge
+   * `server/src/generate.ts` `ScaffoldkitResult.skipped`:
+   *   - `no_input`         CLI didn't write scaffoldkit-input.json (ENOENT)
+   *   - `input_unreadable` file exists but JSON.parse / IO failed (CLI bug)
+   *   - `opt_out`          caller passed `scaffold: false`
+   *   - `not_installed`    SCAFFOLDKIT_PYTHON binary is missing (dev/tests)
+   * Keep in sync with the server union; an unknown string flows through
+   * verbatim via the `?? "unknown"` fallback in `assertScaffoldkitRan`.
+   */
+  skipped?: "no_input" | "input_unreadable" | "opt_out" | "not_installed";
+  /**
+   * Populated only when `skipped === "input_unreadable"`. Carries the
+   * underlying error message (JSON.parse text or IO errno) so callers
+   * can distinguish a CLI bug from a permission issue without rerunning.
+   */
+  inputReadError?: string;
 }
 
 export interface PlanforgeRunResult {
@@ -100,8 +116,13 @@ export function assertScaffoldkitRan(result: PlanforgeRunResult): void {
       `scaffoldkit ran but exited ${sk.exitCode ?? "unknown"}: ${sk.stderr?.slice(0, 200) ?? "no stderr"}`,
     );
   }
+  const reason = sk.skipped ?? "unknown";
+  const detail =
+    sk.skipped === "input_unreadable" && sk.inputReadError
+      ? ` (${sk.inputReadError})`
+      : "";
   throw new PlanforgeClientError(
-    `scaffoldkit did not run (skipped: ${sk.skipped ?? "unknown"}); published repo would be missing scaffolded files`,
+    `scaffoldkit did not run (skipped: ${reason}${detail}); published repo would be missing scaffolded files`,
   );
 }
 

--- a/tests/integration/planforge-client.test.ts
+++ b/tests/integration/planforge-client.test.ts
@@ -277,6 +277,25 @@ describe("assertScaffoldkitRan", () => {
     ).toThrow(/exited 7/);
   });
 
+  it("surfaces the underlying parser error when skipped is input_unreadable", () => {
+    // The input_unreadable branch (added in agent-planforge PR #71)
+    // indicates a CLI bug, not a normal skip. The thrown error must
+    // carry the parser's message so operators can act on it without
+    // re-running the request.
+    expect(() =>
+      assertScaffoldkitRan({
+        requestId: "r",
+        planOutput: {},
+        scaffoldkitInput: null,
+        scaffoldkit: {
+          invoked: false,
+          skipped: "input_unreadable",
+          inputReadError: "Unexpected token { in JSON at position 12",
+        },
+      }),
+    ).toThrow(/input_unreadable.*Unexpected token/);
+  });
+
   it("is tolerant when the service predates the scaffoldkit-metadata contract", () => {
     // Old planforge deploys don't emit the `scaffoldkit` field at all.
     // Don't block project-forge until the whole fleet is upgraded.

--- a/tests/integration/planforge-client.test.ts
+++ b/tests/integration/planforge-client.test.ts
@@ -277,6 +277,20 @@ describe("assertScaffoldkitRan", () => {
     ).toThrow(/exited 7/);
   });
 
+  it("handles input_unreadable without the inputReadError field cleanly", () => {
+    // Defensive: a transitional planforge deploy that emits the new
+    // skipped value but not yet the inputReadError field should still
+    // produce a clean error message (just without the parser detail).
+    expect(() =>
+      assertScaffoldkitRan({
+        requestId: "r",
+        planOutput: {},
+        scaffoldkitInput: null,
+        scaffoldkit: { invoked: false, skipped: "input_unreadable" },
+      }),
+    ).toThrow(/skipped: input_unreadable\)/);
+  });
+
   it("surfaces the underlying parser error when skipped is input_unreadable", () => {
     // The input_unreadable branch (added in agent-planforge PR #71)
     // indicates a CLI bug, not a normal skip. The thrown error must


### PR DESCRIPTION
## Summary

agent-planforge PR #71 added a fifth `skipped` value `"input_unreadable"` plus an optional `inputReadError?: string` to `ScaffoldkitResult` on the `done` event. The local mirror in `lib/planforge-client.ts` was stale.

- Extends `ScaffoldkitResult.skipped` union with `"input_unreadable"` and adds optional `inputReadError?: string`. JSDoc lists all four reasons with a "keep in sync with server" note.
- `assertScaffoldkitRan` appends the `inputReadError` text to its thrown message when the skip reason is `input_unreadable`, so the operator sees the underlying JSON.parse / IO error without re-running. Other skip reasons unchanged.
- Two new tests cover (1) input_unreadable with inputReadError populated, asserting the parser message rides out, (2) the transitional deploy case where `input_unreadable` arrives without `inputReadError` falls through cleanly.

No runtime bug pre-PR: `assertScaffoldkitRan` already passes unknown skipped strings through verbatim via the `?? "unknown"` fallback. The widening makes the contract explicit so a future exhaustive switch covers the new value.

## Review

Rigorous review subagent verdict: `APPROVE` (no nits worth fixing). Reviewer verified:
- The local mirror at `lib/planforge-client.ts:54-73` now matches the server interface at `agent-planforge/server/src/generate.ts:77-97` 1:1.
- No exhaustive `switch (sk.skipped)` anywhere in project-forge; the union widening is purely additive, no newly-reachable default arms.
- The `assertScaffoldkitRan` message append is backward-safe (only fires when both `skipped === "input_unreadable"` AND `inputReadError` is truthy).
- Existing `/not_installed/` and `/exited 7/` substring tests are unaffected by the append.
- Scope is exactly the 2 claimed files.

One optional transitional-deploy coverage gap (input_unreadable without inputReadError) added in `e1aa82c`.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` clean
- [x] `npx vitest run tests/integration/planforge-client.test.ts` → 13/13 (12 prior + 1 widening + 1 transitional)
- [x] `npm run lint` 0 errors (2 pre-existing unused-var warnings, separate concern)
- [x] `harness preflight` READY confidence 74%
- [x] No drive-by edits outside the 2 target files
