### PR TITLE
fix: bump brace-expansion and ws to patch CVE-2026-45149

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3595,9 +3595,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -9911,9 +9911,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "devOptional": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## What

Patches CVE-2026-45149 by bumping the transitive dependency `brace-expansion` from 5.0.5 to 5.0.6 in `package-lock.json`.

GHSA-jxxr-4gwj-5jf2: in brace-expansion >=5.0.0 <5.0.6 a large numeric range defeats the documented `max` DoS protection.

The same `npm audit fix` run also bumped `ws` 8.20.0 to 8.20.1, which closes a moderate uninitialized-memory disclosure flagged by `npm audit` on this repo.

## Scope

Lockfile-only. `package.json` is untouched, so no direct dependency ranges change. Both bumps are within-major patch releases.

## Verification

- `npm audit`: 0 vulnerabilities (was 2 moderate).
- `npm run typecheck`: clean.
- `npm test`: 66 passed.
- Reviewed by review subagent: APPROVE, integrity hashes verified against npm registry.

Part of the 2026-05-20 CVE sweep across 5 repos flagged by agent-ops-dashboard. Task: agent-tasks b8e68fcd.