### PR TITLE
docs: align README + compose comment with Next 15 and relative planforge path

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ make deploy
 The root `docker-compose.yml` ships two services:
 
 - `app` — the project-forge Next.js runtime.
-- `planforge` — the agent-planforge HTTP service (per [ADR-0002](docs/adrs/0002-tool-decoupling-service-boundary.md)). Built from `/root/git/agent-planforge/server/Dockerfile`. Runs both the planforge CLI and scaffoldkit in-container. **Internal-only** — no Traefik labels, no published ports. `app` reaches it via the shared `traefik` docker network at `http://planforge:8223`.
+- `planforge`: the agent-planforge HTTP service (per [ADR-0002](docs/adrs/0002-tool-decoupling-service-boundary.md)). Built from the sibling `agent-planforge` checkout via `context: ../agent-planforge` (see `docker-compose.yml`). Runs both the planforge CLI and scaffoldkit in-container. **Internal-only**, no Traefik labels, no published ports. `app` reaches it via the shared `traefik` docker network at `http://planforge:8223`.
 
 Both services need `PLANFORGE_SERVICE_TOKEN` in `.env`. Compose propagates it; mismatched values cause `app` to get 401s from `planforge`.
 
@@ -155,7 +155,7 @@ Full API documentation: [project-forge.opentriologue.ai/docs](https://project-fo
 
 ## Tech Stack
 
-- **Frontend:** Next.js 14 + TypeScript + Tailwind CSS
+- **Frontend:** Next.js 15 + TypeScript + Tailwind CSS
 - **Auth:** next-auth (email/password + GitHub OAuth)
 - **Database:** SQLite via Prisma (API tokens, users)
 - **Planning + Scaffolding:** [agent-planforge](https://github.com/LanNguyenSi/agent-planforge) HTTP service (bundles [scaffoldkit](https://github.com/LanNguyenSi/scaffoldkit) in its own container; project-forge is Node-only)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,10 +36,10 @@ services:
 
   # ── agent-planforge HTTP service (ADR-0002) ───────────────────────────
   #
-  # Built from the agent-planforge repo checked out at the sibling path
-  # /root/git/agent-planforge. The image ships the planforge CLI, the
-  # TypeScript HTTP layer, AND a pinned scaffoldkit venv that runs
-  # scaffoldkit server-side — see `agent-planforge/server/Dockerfile`.
+  # Built from the agent-planforge repo checked out as a sibling
+  # (context: ../agent-planforge below). The image ships the planforge CLI,
+  # the TypeScript HTTP layer, AND a pinned scaffoldkit venv that runs
+  # scaffoldkit server-side, see `agent-planforge/server/Dockerfile`.
   #
   # Intentionally NOT Traefik-exposed. Access is scoped to the shared
   # `traefik` docker network, where project-forge reaches it via the


### PR DESCRIPTION
## Summary

Two README drifts plus a matching comment drift:

- `README.md:158` Tech Stack listed "Next.js 14" while `package.json` declares `next@^15.5.18`. Bumped to "Next.js 15".
- `README.md:64` claimed planforge was "Built from `/root/git/agent-planforge/server/Dockerfile`". `docker-compose.yml:50` actually uses `context: ../agent-planforge` (relative sibling). Reworded to describe the sibling-checkout setup and point at the compose file as source of truth.
- `docker-compose.yml:39-42` had the same stale absolute path inside a comment. Rewritten to match the actual relative context.

Closes: agent-tasks README drift audit 2026-05-25 (Next.js 14 vs 15, Docker path).

## Reviewer notes (subagent, rigorous)

- `next@^15.5.18` verified in `package.json:20`, README claim now matches the major.
- `docker-compose.yml:48-51` confirms `context: ../agent-planforge` + `dockerfile: server/Dockerfile`, so the new prose is accurate.
- `README.md:71 cd /root/git/project-forge` left as-is: deployment install path, intentional, out of audit scope.
- Inline cleanup: em-dashes on the touched `README.md:64` line converted to comma/colon per the no-em-dashes preference. Pre-existing em-dashes on other lines untouched.

## Test plan

- [x] `node -e "console.log(require('./package.json').dependencies.next)"` returns `^15.5.18` → matches README "Next.js 15"
- [x] `git diff main..HEAD --stat` → `README.md | 4 ++--, docker-compose.yml | 8 ++++----` (6 insertions, 6 deletions)
- [x] No other `next 14` / `Next.js 14` references in repo (grep clean)