### PR TITLE
fix(auth): persist forwarded GitHub OAuth token as githubPat

### DIFF
--- a/app/api/auth/register-from-project-pilot/route.ts
+++ b/app/api/auth/register-from-project-pilot/route.ts
@@ -48,6 +48,9 @@ export async function POST(req: NextRequest) {
       { status: 400 },
     );
   }
+  // Capture the validated token: control-flow narrowing on body.githubAccessToken
+  // is lost across the GitHub-verification call below, so hold a typed const.
+  const githubAccessToken: string = body.githubAccessToken;
   if (body.githubLogin !== undefined && typeof body.githubLogin !== "string") {
     return NextResponse.json(
       { error: "bad_request", message: "githubLogin must be a string if provided" },
@@ -57,7 +60,7 @@ export async function POST(req: NextRequest) {
 
   let githubUser;
   try {
-    githubUser = await fetchGitHubUser(body.githubAccessToken);
+    githubUser = await fetchGitHubUser(githubAccessToken);
   } catch (err) {
     if (err instanceof GitHubAuthError) {
       return NextResponse.json(
@@ -144,8 +147,12 @@ export async function POST(req: NextRequest) {
         data: {
           githubLogin: githubUser.login,
           email: githubEmail ?? existingByGithubId.email,
-          // Keep githubPat/githubOwner/passwordHash untouched — this endpoint
-          // never overwrites existing project-forge-specific credentials.
+          // Backfill githubPat from the verified OAuth access-token, but only
+          // when the user has none yet. This lets a project-pilot SSO user
+          // publish (create + push repos) without a second GitHub step, while
+          // never clobbering a classic PAT the user entered manually in the
+          // forge dashboard. githubOwner/passwordHash stay untouched.
+          ...(existingByGithubId.githubPat ? {} : { githubPat: githubAccessToken }),
         },
       })
     : await prisma.user.create({
@@ -153,6 +160,11 @@ export async function POST(req: NextRequest) {
           githubId,
           githubLogin: githubUser.login,
           email: githubEmail,
+          // Store the verified OAuth access-token as the GitHub PAT so a
+          // project-pilot SSO user can publish immediately, without connecting
+          // GitHub a second time on the forge side. pilot's OAuth requests the
+          // `repo` scope, which is what createAndPushRepo needs.
+          githubPat: githubAccessToken,
           // OAuth-provisioned users have no password; column is nullable.
         },
       });

--- a/tests/integration/register-from-project-pilot.test.ts
+++ b/tests/integration/register-from-project-pilot.test.ts
@@ -212,6 +212,94 @@ describe("POST /api/auth/register-from-project-pilot", () => {
     }
   });
 
+  it("stores the verified OAuth token as githubPat when provisioning a new user", async () => {
+    fetchMock.mockResolvedValue({
+      id: 42,
+      login: "newbie",
+      name: "New",
+      avatar_url: "",
+      email: "new@example.com",
+    });
+    user.findUnique.mockResolvedValue(null);
+    user.create.mockResolvedValue({ id: "user-1" });
+    apiToken.findFirst.mockResolvedValue(null);
+    apiToken.create.mockResolvedValue({});
+
+    await POST(makeReq({ githubAccessToken: "gho_oauth_token", githubLogin: "newbie" }));
+
+    expect(user.create).toHaveBeenCalledTimes(1);
+    expect(user.create.mock.calls[0][0].data.githubPat).toBe("gho_oauth_token");
+  });
+
+  it("backfills githubPat on an existing user that has none yet", async () => {
+    fetchMock.mockResolvedValue({
+      id: 99,
+      login: "returning",
+      name: null,
+      avatar_url: "",
+      email: null,
+    });
+    user.findUnique.mockResolvedValue({
+      id: "user-existing",
+      githubId: "99",
+      email: null,
+      githubPat: null,
+    });
+    user.update.mockResolvedValue({ id: "user-existing" });
+    apiToken.findFirst.mockResolvedValue({ token: "pf_x", revokedAt: null });
+
+    await POST(makeReq({ githubAccessToken: "gho_fresh_token" }));
+
+    expect(user.update).toHaveBeenCalledTimes(1);
+    expect(user.update.mock.calls[0][0].data.githubPat).toBe("gho_fresh_token");
+  });
+
+  it("treats an empty-string githubPat as 'none' and backfills it", async () => {
+    fetchMock.mockResolvedValue({
+      id: 99,
+      login: "returning",
+      name: null,
+      avatar_url: "",
+      email: null,
+    });
+    user.findUnique.mockResolvedValue({
+      id: "user-existing",
+      githubId: "99",
+      email: null,
+      githubPat: "",
+    });
+    user.update.mockResolvedValue({ id: "user-existing" });
+    apiToken.findFirst.mockResolvedValue({ token: "pf_x", revokedAt: null });
+
+    await POST(makeReq({ githubAccessToken: "gho_backfilled" }));
+
+    expect(user.update.mock.calls[0][0].data.githubPat).toBe("gho_backfilled");
+  });
+
+  it("does NOT overwrite a manually-set githubPat on an existing user", async () => {
+    fetchMock.mockResolvedValue({
+      id: 99,
+      login: "returning",
+      name: null,
+      avatar_url: "",
+      email: null,
+    });
+    user.findUnique.mockResolvedValue({
+      id: "user-existing",
+      githubId: "99",
+      email: null,
+      githubPat: "ghp_manual_classic_pat",
+    });
+    user.update.mockResolvedValue({ id: "user-existing" });
+    apiToken.findFirst.mockResolvedValue({ token: "pf_x", revokedAt: null });
+
+    await POST(makeReq({ githubAccessToken: "gho_should_be_ignored" }));
+
+    expect(user.update).toHaveBeenCalledTimes(1);
+    // No githubPat key in the update payload → the existing PAT is preserved.
+    expect(user.update.mock.calls[0][0].data).not.toHaveProperty("githubPat");
+  });
+
   it("never leaks the GitHub access-token in response bodies (including errors)", async () => {
     fetchMock.mockRejectedValue(new GitHubAuthError("401"));
     const res = await POST(makeReq({ githubAccessToken: "super-secret-value-xyz" }));


### PR DESCRIPTION
## Problem

A project-pilot user who signs in with GitHub OAuth gets `400 "GitHub PAT not configured"` when they hit **Publish**. pilot already authenticated them with GitHub and forwards a verified `githubAccessToken` (with `repo` scope) to `register-from-project-pilot`, but forge discarded it: neither the create nor the update branch ever set `user.githubPat`. So the user was forced to connect GitHub a second time on the forge side, which is exactly the duplication SSO is supposed to remove.

## Fix

`app/api/auth/register-from-project-pilot/route.ts` now persists the verified token as `githubPat`:

- **create:** always set it.
- **update:** set it only when the user has none yet, so a classic `ghp_` PAT entered manually in the forge dashboard is never overwritten (that was the intent of the old "keep untouched" comment).

The token is already verified against `api.github.com/user` at this point, so nothing new is trusted. This also matches `lib/auth.ts`, which already stores the NextAuth `access_token` as `githubPat` for the regular login path.

A typed `const githubAccessToken` is captured right after the existing validation guard, because control-flow narrowing on `body.githubAccessToken` is lost across the GitHub-verification call.

## Dependency

Works because pilot requests `repo` scope (`project-pilot` `github-oauth.ts`). `createAndPushRepo` uses the value as a Bearer credential and as an `x-access-token:` git credential, both of which accept a `gho_` OAuth token with `repo` scope.

## Test plan

- `npm run typecheck` + `npm run test` (69 tests, 4 new: create sets githubPat, update backfills when null, update backfills empty-string, update preserves an existing `ghp_` PAT).
- Reviewed by a review subagent: no blockers, one consistency fix applied (use the captured const at the verification call too).

## Out of scope

`app/api/dashboard/route.ts` returns `githubPat` in the dashboard payload. That predates this change and is consistent with how `lib/auth.ts` already stored OAuth tokens; flagging it as a separate follow-up rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)