### PR TITLE
fix(publish): refresh OAuth-derived PAT on login + surface push failure reason

### DIFF
--- a/app/api/auth/register-from-project-pilot/route.ts
+++ b/app/api/auth/register-from-project-pilot/route.ts
@@ -141,18 +141,23 @@ export async function POST(req: NextRequest) {
     }
   }
 
+  // Decide whether to (re)store the verified OAuth token as githubPat. Refresh
+  // it when there is none yet OR when the existing value is itself an OAuth
+  // token (gho_): that way scope upgrades on the project-pilot side (e.g.
+  // adding `workflow`) propagate on the next login instead of leaving the old,
+  // narrower-scoped token stuck. A manually-entered PAT (classic ghp_ or
+  // fine-grained github_pat_) is preserved, never overwritten.
+  const existingPat = existingByGithubId?.githubPat ?? null;
+  const preserveManualPat = !!existingPat && !existingPat.startsWith("gho_");
+
   const user = existingByGithubId
     ? await prisma.user.update({
         where: { id: existingByGithubId.id },
         data: {
           githubLogin: githubUser.login,
           email: githubEmail ?? existingByGithubId.email,
-          // Backfill githubPat from the verified OAuth access-token, but only
-          // when the user has none yet. This lets a project-pilot SSO user
-          // publish (create + push repos) without a second GitHub step, while
-          // never clobbering a classic PAT the user entered manually in the
-          // forge dashboard. githubOwner/passwordHash stay untouched.
-          ...(existingByGithubId.githubPat ? {} : { githubPat: githubAccessToken }),
+          // githubOwner/passwordHash stay untouched.
+          ...(preserveManualPat ? {} : { githubPat: githubAccessToken }),
         },
       })
     : await prisma.user.create({

--- a/app/api/v1/publish/route.ts
+++ b/app/api/v1/publish/route.ts
@@ -96,18 +96,52 @@ export async function POST(req: NextRequest) {
       },
     });
   } catch (error: unknown) {
-    // Sanitize PAT from error messages before logging
-    const msg = error instanceof Error ? error.message : String(error);
-    console.error("Publish failed:", msg.replace(/x-access-token:[^@]+@/g, "x-access-token:***@"));
+    // Sanitize any embedded PAT before it touches logs or the response.
+    // First the known `x-access-token:TOKEN@` remote-URL form, then a
+    // defense-in-depth scrub of bare GitHub token shapes in case the auth
+    // embedding ever changes (Authorization header echo, `https://TOKEN@`, …).
+    const raw = error instanceof Error ? error.message : String(error);
+    const sanitized = raw
+      .replace(/x-access-token:[^@]+@/g, "x-access-token:***@")
+      .replace(/\b(gho|ghp|ghu|ghs)_[A-Za-z0-9]+/g, "$1_***")
+      .replace(/\bgithub_pat_[A-Za-z0-9_]+/g, "github_pat_***");
+    console.error("Publish failed:", sanitized);
 
     // Cleanup temp dir on failure (PAT may be in .git/config)
     if (tempDir) await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
 
+    // Surface *why* publish failed instead of an opaque "Publish failed":
+    // project-pilot forwards `error` to the UI, so the reason (e.g. a missing
+    // `workflow` OAuth scope on a git push) reaches the user. `details` carries
+    // the fuller sanitized message for direct API callers.
     return NextResponse.json<ErrorResponse>(
-      { ok: false, error: "Publish failed" },
+      { ok: false, error: `Publish failed: ${summarizePublishError(sanitized)}`, details: sanitized.slice(0, 1000) },
       { status: 500 },
     );
   }
+}
+
+/**
+ * Turn a raw (PAT-sanitized) failure message into a short, user-facing reason.
+ * Maps the known createAndPushRepo error codes; otherwise surfaces the most
+ * telling line of git's captured stderr (e.g. a "remote rejected" push error).
+ */
+export function summarizePublishError(sanitized: string): string {
+  // The createAndPushRepo codes are thrown as the *entire* error message
+  // ("repo_name_exists" / "github_422"). Anchor on that so a 3-digit run
+  // inside a multi-line git-push stderr blob can't be misread as an HTTP code.
+  const trimmed = sanitized.trim();
+  if (/^(?:Error:\s*)?repo_name_exists$/.test(trimmed)) {
+    return "a repository with that name already exists on your GitHub account";
+  }
+  const ghMatch = trimmed.match(/^(?:Error:\s*)?github_(\d{3})$/);
+  if (ghMatch) return `GitHub rejected the request (HTTP ${ghMatch[1]})`;
+
+  const lines = sanitized.split("\n").map((l) => l.trim()).filter(Boolean);
+  const telling = lines.find((l) => /\[remote rejected\]|^remote:|^error:|refusing to/i.test(l));
+  if (telling) return telling.replace(/^remote:\s*/i, "").slice(0, 300);
+
+  return (lines[lines.length - 1] ?? "unknown error").slice(0, 300);
 }
 
 async function createAndPushRepo(projectDir: string, repoName: string, githubPat: string): Promise<string> {

--- a/app/api/v1/publish/route.ts
+++ b/app/api/v1/publish/route.ts
@@ -3,6 +3,7 @@ import { validateApiToken, checkRateLimit, prisma } from "@/lib/db";
 import * as fs from "fs/promises";
 import * as path from "path";
 import type { ErrorResponse } from "@/lib/types";
+import { summarizePublishError } from "@/lib/publish-error";
 import { runCommand } from "@/lib/subprocess";
 import { SESSION_UUID_RE, readForgeMeta, isSessionExpired } from "@/lib/v1-shared";
 
@@ -119,29 +120,6 @@ export async function POST(req: NextRequest) {
       { status: 500 },
     );
   }
-}
-
-/**
- * Turn a raw (PAT-sanitized) failure message into a short, user-facing reason.
- * Maps the known createAndPushRepo error codes; otherwise surfaces the most
- * telling line of git's captured stderr (e.g. a "remote rejected" push error).
- */
-export function summarizePublishError(sanitized: string): string {
-  // The createAndPushRepo codes are thrown as the *entire* error message
-  // ("repo_name_exists" / "github_422"). Anchor on that so a 3-digit run
-  // inside a multi-line git-push stderr blob can't be misread as an HTTP code.
-  const trimmed = sanitized.trim();
-  if (/^(?:Error:\s*)?repo_name_exists$/.test(trimmed)) {
-    return "a repository with that name already exists on your GitHub account";
-  }
-  const ghMatch = trimmed.match(/^(?:Error:\s*)?github_(\d{3})$/);
-  if (ghMatch) return `GitHub rejected the request (HTTP ${ghMatch[1]})`;
-
-  const lines = sanitized.split("\n").map((l) => l.trim()).filter(Boolean);
-  const telling = lines.find((l) => /\[remote rejected\]|^remote:|^error:|refusing to/i.test(l));
-  if (telling) return telling.replace(/^remote:\s*/i, "").slice(0, 300);
-
-  return (lines[lines.length - 1] ?? "unknown error").slice(0, 300);
 }
 
 async function createAndPushRepo(projectDir: string, repoName: string, githubPat: string): Promise<string> {

--- a/lib/publish-error.ts
+++ b/lib/publish-error.ts
@@ -1,0 +1,26 @@
+/**
+ * Turn a raw (PAT-sanitized) publish failure message into a short, user-facing
+ * reason. Maps the known createAndPushRepo error codes; otherwise surfaces the
+ * most telling line of git's captured stderr (e.g. a "remote rejected" push
+ * error such as a missing `workflow` OAuth scope).
+ *
+ * Lives in lib/ rather than the route module because Next.js route files may
+ * only export HTTP handlers and a fixed set of config fields.
+ */
+export function summarizePublishError(sanitized: string): string {
+  // The createAndPushRepo codes are thrown as the *entire* error message
+  // ("repo_name_exists" / "github_422"). Anchor on that so a 3-digit run
+  // inside a multi-line git-push stderr blob can't be misread as an HTTP code.
+  const trimmed = sanitized.trim();
+  if (/^(?:Error:\s*)?repo_name_exists$/.test(trimmed)) {
+    return "a repository with that name already exists on your GitHub account";
+  }
+  const ghMatch = trimmed.match(/^(?:Error:\s*)?github_(\d{3})$/);
+  if (ghMatch) return `GitHub rejected the request (HTTP ${ghMatch[1]})`;
+
+  const lines = sanitized.split("\n").map((l) => l.trim()).filter(Boolean);
+  const telling = lines.find((l) => /\[remote rejected\]|^remote:|^error:|refusing to/i.test(l));
+  if (telling) return telling.replace(/^remote:\s*/i, "").slice(0, 300);
+
+  return (lines[lines.length - 1] ?? "unknown error").slice(0, 300);
+}

--- a/tests/integration/register-from-project-pilot.test.ts
+++ b/tests/integration/register-from-project-pilot.test.ts
@@ -276,6 +276,51 @@ describe("POST /api/auth/register-from-project-pilot", () => {
     expect(user.update.mock.calls[0][0].data.githubPat).toBe("gho_backfilled");
   });
 
+  it("refreshes an existing OAuth (gho_) githubPat so scope upgrades propagate", async () => {
+    fetchMock.mockResolvedValue({
+      id: 99,
+      login: "returning",
+      name: null,
+      avatar_url: "",
+      email: null,
+    });
+    user.findUnique.mockResolvedValue({
+      id: "user-existing",
+      githubId: "99",
+      email: null,
+      // Old OAuth token (e.g. without the workflow scope).
+      githubPat: "gho_old_narrow_scope_token",
+    });
+    user.update.mockResolvedValue({ id: "user-existing" });
+    apiToken.findFirst.mockResolvedValue({ token: "pf_x", revokedAt: null });
+
+    await POST(makeReq({ githubAccessToken: "gho_new_token_with_workflow" }));
+
+    expect(user.update.mock.calls[0][0].data.githubPat).toBe("gho_new_token_with_workflow");
+  });
+
+  it("does NOT overwrite a manually-set fine-grained (github_pat_) githubPat", async () => {
+    fetchMock.mockResolvedValue({
+      id: 99,
+      login: "returning",
+      name: null,
+      avatar_url: "",
+      email: null,
+    });
+    user.findUnique.mockResolvedValue({
+      id: "user-existing",
+      githubId: "99",
+      email: null,
+      githubPat: "github_pat_manual_finegrained",
+    });
+    user.update.mockResolvedValue({ id: "user-existing" });
+    apiToken.findFirst.mockResolvedValue({ token: "pf_x", revokedAt: null });
+
+    await POST(makeReq({ githubAccessToken: "gho_should_be_ignored" }));
+
+    expect(user.update.mock.calls[0][0].data).not.toHaveProperty("githubPat");
+  });
+
   it("does NOT overwrite a manually-set githubPat on an existing user", async () => {
     fetchMock.mockResolvedValue({
       id: 99,

--- a/tests/unit/summarize-publish-error.test.ts
+++ b/tests/unit/summarize-publish-error.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { summarizePublishError } from "@/app/api/v1/publish/route";
+
+describe("summarizePublishError", () => {
+  it("maps the repo-name-exists code to a friendly reason", () => {
+    expect(summarizePublishError("Error: repo_name_exists")).toMatch(/already exists/i);
+  });
+
+  it("maps a github_<status> code to an HTTP reason", () => {
+    expect(summarizePublishError("Error: github_422")).toBe("GitHub rejected the request (HTTP 422)");
+  });
+
+  it("surfaces the git remote-rejected line (e.g. missing workflow scope)", () => {
+    const raw = [
+      "git exited with code 1",
+      "Stdout: ",
+      "Stderr: To https://github.com/lan/todo-app.git",
+      " ! [remote rejected] main -> main (refusing to allow an OAuth App to create or update workflow `.github/workflows/ci.yml` without `workflow` scope)",
+      "error: failed to push some refs",
+    ].join("\n");
+    const out = summarizePublishError(raw);
+    expect(out).toMatch(/\[remote rejected\]/);
+    expect(out).toMatch(/workflow.*scope/i);
+  });
+
+  it("strips a leading remote: prefix", () => {
+    expect(summarizePublishError("remote: error: something went wrong")).toBe("error: something went wrong");
+  });
+
+  it("falls back to the last non-empty line for unrecognized errors", () => {
+    expect(summarizePublishError("line one\nline two\n\n")).toBe("line two");
+  });
+
+  it("does NOT misread a github_NNN substring inside a push blob as an HTTP code", () => {
+    const raw = [
+      "git exited with code 1",
+      "Stderr: ! [remote rejected] main -> main (push declined by github_500 rule)",
+    ].join("\n");
+    // The github_NNN match is anchored to the whole thrown code, so a blob
+    // mentioning it surfaces the remote-rejected line instead.
+    const out = summarizePublishError(raw);
+    expect(out).toMatch(/\[remote rejected\]/);
+    expect(out).not.toBe("GitHub rejected the request (HTTP 500)");
+  });
+
+  it("returns a safe fallback for empty input", () => {
+    expect(summarizePublishError("")).toBe("unknown error");
+    expect(summarizePublishError("   \n  \n")).toBe("unknown error");
+  });
+
+  it("never contains a leaked token (already sanitized upstream)", () => {
+    // The caller sanitizes x-access-token:...@ before calling; confirm the
+    // summarizer doesn't re-introduce anything from a clean input.
+    const out = summarizePublishError("Stderr: ! [remote rejected] main -> main (push declined)");
+    expect(out).not.toMatch(/x-access-token/);
+  });
+});

--- a/tests/unit/summarize-publish-error.test.ts
+++ b/tests/unit/summarize-publish-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { summarizePublishError } from "@/app/api/v1/publish/route";
+import { summarizePublishError } from "@/lib/publish-error";
 
 describe("summarizePublishError", () => {
   it("maps the repo-name-exists code to a friendly reason", () => {


### PR DESCRIPTION
## Context

Follow-up to the SSO publish diagnosis: a pilot OAuth user's publish failed at `git push` because the forwarded token lacked the `workflow` scope, and forge returned an opaque `{error:"Publish failed"}` that hid the reason. The companion project-pilot PR adds `workflow` to the OAuth scope; this PR makes forge propagate the upgraded token and surface failures.

## Fix A: refresh the OAuth-derived githubPat on login

`register-from-project-pilot` previously set `githubPat` only when it was null (to protect manual PATs). That meant a pilot-side scope upgrade never landed: the old `gho_` token without `workflow` stayed stuck. Now it refreshes when the stored value is empty or itself an OAuth token (`gho_`), and preserves a manually-entered classic (`ghp_`) or fine-grained (`github_pat_`) PAT.

## Fix B: surface the real publish failure reason

The publish catch returned a generic `Publish failed`. The captured git stderr (e.g. the remote-rejected workflow-scope line) only reached the server log. Now `summarizePublishError` builds a PAT-sanitized, one-line reason into the `error` field, which pilot forwards to the UI. Known codes (`repo_name_exists`, `github_NNN`) map to friendly text; the code match is anchored so a digit run inside a push blob is not misread. The catch also scrubs bare token shapes (`gho_`/`ghp_`/`github_pat_`) as defense-in-depth on top of the existing `x-access-token:...@` scrub.

## Test plan

- `npm run typecheck` + `npm run test` (80 tests). New: gho_ refresh and github_pat_ preserve in the register test; a dedicated `summarizePublishError` unit suite (code mapping, remote-rejected extraction, precedence, empty input, no token leak).
- Reviewed by a review subagent across both repos: no blockers; the anchored code match and the bare-token scrub are the applied review fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)