### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-28
+
+**Headline: Publishing now works for project-pilot SSO users without a second GitHub step. The OAuth token forwarded from pilot is stored and reused to create and push the repo, and when publish fails the real reason surfaces instead of an opaque error. Plus two AI-input hardenings and a round of dependency/security bumps.**
+
+### Added
+
+- **Injection-sentinel wrap for attachment `inlineText`** in the enrichment prompt, so attachment content can no longer smuggle instructions into the LLM call (#58).
+- Mirror planforge's `input_unreadable` skipped value through the generate flow so an unreadable input is surfaced rather than silently dropped (#64).
+
+### Fixed
+
+- **SSO publish: store and reuse the forwarded GitHub OAuth token.** `register-from-project-pilot` persists the verified token as `githubPat` (on create always; on update when none is set or the stored one is itself an OAuth `gho_` token), so a pilot SSO user can publish without connecting GitHub a second time, and a pilot-side scope upgrade propagates on next login. A manually-entered classic (`ghp_`) or fine-grained (`github_pat_`) PAT is never overwritten (#67, #68).
+- **Surface the real publish failure reason.** A failed publish now returns a PAT-sanitized, one-line reason in `error` (e.g. a missing `workflow` OAuth scope on a git push) instead of an opaque "Publish failed". The error path also scrubs bare token shapes as defense-in-depth (#68).
+- Migrate `next lint` to the ESLint CLI and fix the `any` sites it surfaced, unblocking preflight (#63).
+
+### Security
+
+- Bump `next` to ^15.5.18 to patch 3 high-severity CVEs (#62).
+- Bump `brace-expansion` and `ws` to patch CVE-2026-45149 (#65).
+- Bump `postcss` (XSS, alert #15) (#60) and `uuid` to ^14.0.0 (bounds-check) (#59).
+
+### Documentation
+
+- Open-source surface: Code of Conduct, contributing, security policy, issue + PR templates (#61).
+- Align README and compose comments with Next 15 and the relative planforge path (#66).
+
 ## [0.2.0] - 2026-04-24
 
 **Headline: Attachments land end-to-end. A user can now upload an

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "project-forge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "project-forge",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "bcryptjs": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-forge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Release v0.3.0

Minor bump for two new features plus the SSO publish fixes and a security/deps round, all merged since v0.2.0.

### Included
- **#67 / #68 fix:** SSO publish via project-pilot. Store and reuse the forwarded OAuth token as `githubPat` (refresh on scope upgrade, preserve a manual PAT); surface the real publish failure reason instead of an opaque error.
- **#58 feat:** injection-sentinel wrap for attachment `inlineText` in the enrichment prompt.
- **#64 feat:** mirror planforge `input_unreadable` skipped value.
- **Security:** next ^15.5.18 (3 high CVEs, #62), brace-expansion + ws (#65), postcss (#60), uuid ^14 (#59).
- **Docs/chore:** OSS surface (#61), README/compose alignment (#66), eslint CLI migration (#63).

### Dogfood (live, project-forge.opentriologue.ai)
The SSO publish path was verified end-to-end against production:
- [x] Re-login via project-pilot OAuth: stored `githubPat` refreshed to the new token carrying `read:org, read:user, repo, workflow` (confirmed via `X-OAuth-Scopes` on the prod token).
- [x] Generate then Publish: repo created and scaffold pushed, including `.github/workflows/ci.yml` (the push that previously failed).
- [x] The pilot "Migrate tasks" step then imported the planforge tasks into agent-tasks.
- [x] `npm run typecheck` + `npm run build` + 80 tests green; CI green on the merged PRs.

### Mechanics
- `version` 0.2.0 to 0.3.0; `package-lock.json` regenerated; the `[Unreleased]` CHANGELOG section is now `## [0.3.0]`.
- Merging does not publish: pushing the `v0.3.0` tag triggers `release.yml` (CI then GitHub Release, notes extracted from the `## [0.3.0]` section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)