### PR TITLE
fix(security): guard legacy publish route against sessionId path traversal

### DIFF
--- a/app/api/publish/route.ts
+++ b/app/api/publish/route.ts
@@ -6,6 +6,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import type { PublishResponse, ErrorResponse } from "../../../lib/types";
 import { runCommand } from "@/lib/subprocess";
+import { SESSION_UUID_RE } from "@/lib/v1-shared";
 
 const TEMP_ROOT = process.env.FORGE_TEMP_DIR ?? "/tmp/project-forge";
 
@@ -19,6 +20,13 @@ export async function POST(req: NextRequest) {
     if (!sessionId || !projectName) {
       return NextResponse.json<ErrorResponse>(
         { ok: false, error: "Missing sessionId or projectName" },
+        { status: 400 }
+      );
+    }
+
+    if (!SESSION_UUID_RE.test(sessionId)) {
+      return NextResponse.json<ErrorResponse>(
+        { ok: false, error: "Invalid sessionId" },
         { status: 400 }
       );
     }

--- a/tests/integration/legacy-publish-traversal.test.ts
+++ b/tests/integration/legacy-publish-traversal.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { POST as legacyPublish } from "@/app/api/publish/route";
+import { NextRequest } from "next/server";
+
+describe("legacy POST /api/publish — path traversal guard", () => {
+  it("rejects a traversal sessionId with 400 before touching the filesystem", async () => {
+    const res = await legacyPublish(
+      new NextRequest("http://test/api/publish", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId: "../../etc", projectName: "demo" }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("Invalid sessionId");
+  });
+});


### PR DESCRIPTION
## Summary

The legacy `POST /api/publish` route accepted a request `sessionId` and passed it straight into `path.join(TEMP_ROOT, sessionId)` with no validation. A crafted value such as `../../etc` escaped the temp root, which then drove a `fs.stat` existence probe, a `git` read that could exfiltrate arbitrary repository contents, and a recursive `fs.rm(..., { recursive: true, force: true })` deletion against the attacker-controlled path.

The v1 publish route (`app/api/v1/publish/route.ts`) already validates `sessionId` with `SESSION_UUID_RE` before any `path.join`. This change brings the legacy route to the same standard.

## Fix

- Import `SESSION_UUID_RE` from `@/lib/v1-shared` in `app/api/publish/route.ts`.
- Immediately after the existing missing-field check, return `400 { ok: false, error: 'Invalid sessionId' }` when `SESSION_UUID_RE.test(sessionId)` is false. The guard runs before any filesystem, git, or auth access, so it neutralizes the traversal at the entry point.

## Verification

- `npm run lint`: pass (0 errors; only 2 pre-existing unused-var warnings).
- `npm run typecheck`: pass (`tsc --noEmit`, clean).
- `npm test`: pass (11 files, 81 tests), including a new regression test that posts `sessionId: '../../etc'` and asserts a 400 `Invalid sessionId` response.
- `npm run build`: pass (`next build` compiled all routes and generated 21/21 static pages).

## Scope

- Only the legacy `app/api/publish/route.ts` guard and one regression test were changed.
- `projectName` is not validated because it is not used in a filesystem path.
- The legacy route was not refactored to share the v1 auth/ownership logic; that is a separate, larger change tracked as a follow-up.

Refs: Security audit 2026-05-30 (CRITICAL).