### PR TITLE
fix(security): close IDOR, add auth, and stop PAT leak on legacy generate/publish routes

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { randomUUID } from 'crypto';
 import * as fs from 'fs/promises';
 import * as path from 'path';
@@ -14,6 +16,7 @@ import { buildPlanforgeInput } from '@/lib/planforge-orchestrator';
 import { runPlanforgeViaHttp, PlanforgeClientError, assertScaffoldkitRan } from '@/lib/planforge-client';
 import { readPostScaffoldReview, runPostScaffoldReview, toScaffoldFitPreview } from '@/lib/post-scaffold-review';
 import { writeAttachmentsToScaffold } from '@/lib/scaffold-attachments';
+import { validateProjectName } from '@/lib/v1-shared';
 
 const TEMP_ROOT = process.env.FORGE_TEMP_DIR ?? '/tmp/project-forge';
 // End-to-end cap for plan + scaffold + tar + SSE + untar. Server-side
@@ -24,6 +27,17 @@ export async function POST(req: NextRequest) {
   let sessionId: string | null = null;
 
   try {
+    // Gate the costly plan + scaffold pipeline behind a logged-in session.
+    // Mirrors app/api/publish/route.ts so an anonymous caller can't drive
+    // the planforge/LLM generation, and so the temp dir carries an owner.
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json<ErrorResponse>(
+        { ok: false, error: 'Not authenticated' },
+        { status: 401 }
+      );
+    }
+
     const input: ProjectInput = await req.json();
 
     if (!input.projectName || !input.summary) {
@@ -33,9 +47,28 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    if (!validateProjectName(input.projectName)) {
+      return NextResponse.json<ErrorResponse>(
+        { ok: false, error: 'Invalid projectName. Use only letters, numbers, dots, hyphens, underscores (max 100 chars).' },
+        { status: 400 }
+      );
+    }
+
     sessionId = randomUUID();
     const tempDir = path.join(TEMP_ROOT, sessionId);
     await fs.mkdir(tempDir, { recursive: true });
+
+    // Record ownership so app/api/publish/route.ts can bind the session
+    // dir to its creator (IDOR guard). Matches the v1 generate route's
+    // .forge-meta.json shape, scoped by NextAuth session.user.id.
+    await fs.writeFile(
+      path.join(tempDir, '.forge-meta.json'),
+      JSON.stringify({
+        userId: session.user.id,
+        projectName: input.projectName,
+        createdAt: new Date().toISOString(),
+      })
+    );
 
     // Attachments are a service-layer concern in planforge's contract —
     // they ride alongside `input` in the POST body, not inside it. Peel
@@ -181,9 +214,12 @@ async function buildFileTree(
 
   // Skip certain directories
   const skipDirs = new Set(['node_modules', '.git', 'venv', '__pycache__']);
+  // Skip forge bookkeeping files so they don't surface in the preview or
+  // travel into the published repo (matches lib/v1-shared buildFileTree).
+  const skipFiles = new Set(['.forge-meta.json', '.forge-published']);
 
   for (const entry of entries) {
-    if (skipDirs.has(entry.name)) continue;
+    if (skipDirs.has(entry.name) || skipFiles.has(entry.name)) continue;
 
     const relativePath = basePath ? `${basePath}/${entry.name}` : entry.name;
     const fullPath = path.join(dirPath, entry.name);

--- a/app/api/publish/route.ts
+++ b/app/api/publish/route.ts
@@ -6,11 +6,14 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import type { PublishResponse, ErrorResponse } from "../../../lib/types";
 import { runCommand } from "@/lib/subprocess";
-import { SESSION_UUID_RE } from "@/lib/v1-shared";
+import { SESSION_UUID_RE, readForgeMeta, isSessionExpired } from "@/lib/v1-shared";
 
 const TEMP_ROOT = process.env.FORGE_TEMP_DIR ?? "/tmp/project-forge";
 
 export async function POST(req: NextRequest) {
+  // Hoisted so the catch block can clean up the temp dir on the throw path
+  // (the PAT may be in .git/config until the post-push set-url + rm run).
+  let tempDir = "";
   try {
     const { sessionId, projectName } = await req.json() as {
       sessionId: string;
@@ -53,11 +56,32 @@ export async function POST(req: NextRequest) {
 
     const userToken = user.githubPat;
 
-    const tempDir = path.join(TEMP_ROOT, sessionId);
+    tempDir = path.join(TEMP_ROOT, sessionId);
     const stat = await fs.stat(tempDir).catch(() => null);
     if (!stat) {
       return NextResponse.json<ErrorResponse>(
         { ok: false, error: "Session not found or expired" },
+        { status: 404 }
+      );
+    }
+
+    // Bind the session dir to its creator (IDOR guard). Without this any
+    // authenticated user who learns a valid UUID could publish another
+    // user's scaffold to their own GitHub account. Mirrors the v1 route's
+    // `meta.userId !== tokenRecord.userId` check, scoped by session.user.id.
+    // A missing/unreadable meta file fails closed (404).
+    const meta = await readForgeMeta(tempDir).catch(() => null);
+    if (!meta || meta.userId !== session.user.id) {
+      return NextResponse.json<ErrorResponse>(
+        { ok: false, error: "Session not found or expired" },
+        { status: 404 }
+      );
+    }
+
+    if (isSessionExpired(meta)) {
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      return NextResponse.json<ErrorResponse>(
+        { ok: false, error: "Session expired" },
         { status: 404 }
       );
     }
@@ -123,9 +147,25 @@ export async function POST(req: NextRequest) {
       },
     });
   } catch (error: unknown) {
-    const msg = error instanceof Error ? error.message : String(error);
+    // Sanitize any embedded PAT before it reaches the client or logs. A
+    // failed `git push` to an authed remote echoes the URL (and thus the
+    // token) in git's stderr. Mirrors the v1 route's scrubbing: the known
+    // `TOKEN@`/`x-access-token:TOKEN@` remote form plus bare GitHub token
+    // shapes as defense in depth.
+    const raw = error instanceof Error ? error.message : String(error);
+    const sanitized = raw
+      .replace(/x-access-token:[^@]+@/g, "x-access-token:***@")
+      .replace(/https:\/\/[^@\s/]+@/g, "https://***@")
+      .replace(/\b(gho|ghp|ghu|ghs)_[A-Za-z0-9]+/g, "$1_***")
+      .replace(/\bgithub_pat_[A-Za-z0-9_]+/g, "github_pat_***");
+    console.error("Publish failed:", sanitized);
+
+    // Always remove the temp dir on failure: on the throw path the cleanup
+    // at the success branch never runs, leaving the PAT in .git/config.
+    if (tempDir) await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+
     return NextResponse.json<ErrorResponse>(
-      { ok: false, error: "Publish failed", details: msg },
+      { ok: false, error: "Publish failed", details: sanitized },
       { status: 500 }
     );
   }
@@ -139,7 +179,16 @@ async function runGitCommands(
   const authedUrl = cloneUrl.replace("https://", `https://${token}@`);
 
   const git = (args: string[], timeoutMs = 10_000) =>
-    runCommand("git", args, { cwd: repoPath, timeoutMs });
+    runCommand("git", args, {
+      cwd: repoPath,
+      timeoutMs,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    });
+
+  // Strip forge bookkeeping so the ownership record never lands in the
+  // published repo (matches the v1 createAndPushRepo flow).
+  await fs.rm(path.join(repoPath, ".forge-meta.json"), { force: true }).catch(() => {});
+  await fs.rm(path.join(repoPath, ".forge-published"), { force: true }).catch(() => {});
 
   await git(["init", "-b", "main"]);
   await git(["config", "user.email", "forge@project-forge.dev"]);
@@ -148,4 +197,7 @@ async function runGitCommands(
   await git(["commit", "-m", "feat: initial scaffold\n\nGenerated with project-forge\nPlanned with agent-planforge (https://github.com/LanNguyenSi/agent-planforge) · Scaffolded with scaffoldkit (https://github.com/LanNguyenSi/scaffoldkit)"]);
   await git(["remote", "add", "origin", authedUrl]);
   await git(["push", "-u", "origin", "main"], 30_000);
+  // Neutralize the PAT from .git/config immediately after push so a token
+  // never survives in the temp dir if later cleanup is skipped.
+  await git(["remote", "set-url", "origin", cloneUrl]);
 }

--- a/lib/v1-shared.ts
+++ b/lib/v1-shared.ts
@@ -15,7 +15,9 @@ export const SESSION_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}
 export const SESSION_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 export interface ForgeMeta {
-  tokenId: string;
+  // Present only for v1 (API-token) sessions; the legacy NextAuth-driven
+  // generate route writes meta without a token, so this is optional.
+  tokenId?: string;
   userId: string;
   projectName: string;
   createdAt: string;


### PR DESCRIPTION
Ports the protections the v1 token-scoped routes already carry onto the older legacy routes, matching the existing v1 idioms (`readForgeMeta`, `isSessionExpired`, the v1 PAT-sanitizer, `remote set-url` cleanup). No new abstractions introduced.

## Findings fixed

- IDOR in legacy publish (app/api/publish/route.ts:65-86): after the `fs.stat` existence check the route now reads `.forge-meta.json` and rejects with 404 when `meta.userId !== session.user.id`, failing closed on a missing or unreadable meta, plus an `isSessionExpired` TTL check. Previously any authenticated user who learned a valid UUID could publish another user's scaffold to their own GitHub account and delete the victim's temp dir. To make ownership recordable, app/api/generate/route.ts:47-58 now writes `.forge-meta.json` (`{userId, projectName, createdAt}`) right after `fs.mkdir`, scoped by NextAuth `session.user.id`, mirroring the v1 generate route.

- Missing auth on legacy generate (app/api/generate/route.ts:30-39): the POST handler now calls `getServerSession(authOptions)` and returns 401 when there is no `session.user.id`, before running the costly planforge/LLM pipeline. This route is not covered by the middleware X-API-Key matcher, so it was reachable unauthenticated, a cost-abuse vector. Also adds `validateProjectName` (app/api/generate/route.ts:50-55) to bound input, matching the v1 route.

- PAT leak in legacy publish (app/api/publish/route.ts): two fixes. (1) The catch block (route.ts:149-168) now sanitizes the error before placing it in `details`, stripping `https://TOKEN@`, `x-access-token:TOKEN@`, and bare `ghp_/gho_/ghu_/ghs_/github_pat_` token shapes (a failed `git push` echoes the authed remote URL, and thus the PAT, in git stderr), and always removes the temp dir on the throw path. (2) `runGitCommands` (route.ts:179-200) now sets `GIT_TERMINAL_PROMPT=0`, strips `.forge-meta.json`/`.forge-published` before commit, and runs `git remote set-url origin <cloneUrl>` after push to neutralize the token left in `.git/config`.

- lib/v1-shared.ts:17-23: `ForgeMeta.tokenId` made optional, since the NextAuth legacy flow has no API token and writes meta without one. The v1 routes still set it.

The legacy `buildFileTree` (app/api/generate/route.ts:217) also now skips `.forge-meta.json`/`.forge-published`, matching `lib/v1-shared` so the new ownership file never surfaces in the preview or travels into the published repo.

## Verification

- `npx tsc --noEmit`: exit 0, clean.
- `npx vitest run`: 11 files / 81 tests passed, 0 failed. The existing legacy-publish-traversal and generate-api contract tests still pass; the UUID-validation early return still fires before the new session check.

Refs: 2026-05-30 security audit (HIGH)