### PR TITLE
refactor(output-layout): honor .planforge/docs relocation in review denylist

### DIFF
--- a/lib/post-scaffold-review.ts
+++ b/lib/post-scaffold-review.ts
@@ -93,11 +93,15 @@ interface ReviewPayload {
 
 // Planforge artifacts that should NOT be counted as runtime scaffold signals.
 // Since the output reorganization (bf7a491), most JSON files moved into
-// planning/, handoff/, and exports/ subdirectories. The directory entries
-// below cover both the subdirs and the root-level markdown/index files.
+// planning/, handoff/, and exports/ subdirectories, and the planning prose
+// docs now live under .planforge/docs/. The directory entries below cover
+// the subdirs (including the .planforge/ namespace) and the root-level
+// markdown/index files. The bare root-level doc names are retained so older
+// flat-root tarballs still match.
 const PLANFORGE_TOP_LEVEL_PATHS = new Set([
   // Directories
   ".ai",
+  ".planforge",
   "adrs",
   "exports",
   "governance",

--- a/tests/integration/planforge-output.test.ts
+++ b/tests/integration/planforge-output.test.ts
@@ -46,13 +46,14 @@ describe("planforge output resolver", () => {
             agents: "AGENTS.md",
             claude: "CLAUDE.md",
             project: "PROJECT.md",
-            charter: "project-charter.md",
-            architecture: "architecture-overview.md",
-            deliveryPlan: "delivery-plan.md",
-            intakeQuestionnaire: "intake-questionnaire.md",
+            charter: ".planforge/docs/project-charter.md",
+            architecture: ".planforge/docs/architecture-overview.md",
+            deliveryPlan: ".planforge/docs/delivery-plan.md",
+            intakeQuestionnaire: ".planforge/docs/intake-questionnaire.md",
           },
           directories: {
             ai: ".ai",
+            docs: ".planforge/docs",
             planning: "planning",
             handoff: "handoff",
             exports: "exports",
@@ -92,6 +93,9 @@ describe("planforge output resolver", () => {
 
     expect(resolved.hasIndex).toBe(true);
     expect(resolved.indexPath).toBe(path.join(tempDir, "planforge-index.json"));
+    expect(resolved.architecturePath).toBe(
+      path.join(tempDir, ".planforge", "docs", "architecture-overview.md")
+    );
     expect(resolved.scaffoldkitInputPath).toBe(
       path.join(tempDir, "exports", "scaffoldkit-input.json")
     );
@@ -140,13 +144,14 @@ describe("planforge output resolver", () => {
             agents: "AGENTS.md",
             claude: "CLAUDE.md",
             project: "PROJECT.md",
-            charter: "project-charter.md",
-            architecture: "architecture-overview.md",
-            deliveryPlan: "delivery-plan.md",
-            intakeQuestionnaire: "intake-questionnaire.md",
+            charter: ".planforge/docs/project-charter.md",
+            architecture: ".planforge/docs/architecture-overview.md",
+            deliveryPlan: ".planforge/docs/delivery-plan.md",
+            intakeQuestionnaire: ".planforge/docs/intake-questionnaire.md",
           },
           directories: {
             ai: ".ai",
+            docs: ".planforge/docs",
             planning: "planning",
             handoff: "handoff",
             exports: "exports",


### PR DESCRIPTION
## Summary

Downstream half of agent-planforge output-layout Phase 1 (agent-planforge#73 relocated the four planning prose docs into `.planforge/docs/`). project-forge's resolver already follows `index.rootFiles.architecture`, so the only required change is the index-blind scaffold-fit denylist.

## Changes

- `lib/post-scaffold-review.ts`: add `".planforge"` to `PLANFORGE_TOP_LEVEL_PATHS`. `collectRuntimePaths` filters top-level entry names against this set, so a top-level `.planforge` membership excludes the whole subtree. Without it, a new-layout tarball's `.planforge/` dir leaks into the reported runtime indicators (`topLevelPaths`, `scaffoldApplied`, and the AI assessment payload). The existing bare doc-name entries are kept so legacy flat-root tarballs still match.
- `tests/integration/planforge-output.test.ts`: point both index fixtures' `rootFiles` doc values at `.planforge/docs/`, add `directories.docs`, and assert `resolved.architecturePath` follows the index to the new location.

## Deliberately unchanged

- The no-index legacy fallback branch (`resolvePlanforgeOutputPaths`'s `if (!index)`): old indexless installs still emit genuine flat-root output, so its hardcoded root paths stay correct.
- The per-key architecture fallback: left as the old root path; the happy path follows the index value.

## Tests

`npm test` (81) and `npm run typecheck` green. The new `architecturePath` assertion locks the resolver-follows-index contract (verified non-tautological by a negative control during review).

## Out of scope (Phase 2)

Version-aware fail-loud resolver, `isPlanforgeIndex` per-group relaxation, collapsing the denylist to index-derived entries, regenerating project-forge's own dogfooded root artifacts.