### PR TITLE
feat(enrichment): per-attachment token budget for small-context providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Per-provider character budget for the intake-enrichment call.** A new `maxContextChars` capability (local 20000, hosted 50000) drives proportional truncation of large uploaded attachment bodies so the enrichment prompt no longer risks a silent context-window overflow on small-context local models; truncation keeps the injection sentinels intact and is surfaced non-silently via `orchestration.attachmentsTruncated`/`notice` and a warning.
+
 ## [0.3.0] - 2026-05-28
 
 **Headline: Publishing now works for project-pilot SSO users without a second GitHub step. The OAuth token forwarded from pilot is stored and reused to create and push the repo, and when publish fails the real reason surfaces instead of an opaque error. Plus two AI-input hardenings and a round of dependency/security bumps.**

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -11,7 +11,29 @@ export interface AiCapabilities {
     intakeEnrichment: boolean;
     postScaffoldReview: boolean;
   };
+  /**
+   * Conservative CHARACTER budget (not a token count) for an enrichment
+   * payload sent to this provider. Used to proportionally truncate large
+   * uploaded attachments so we do not silently overflow a small-context
+   * local model's window. Roughly 4 chars per token, so 20000 chars is a
+   * deliberately cautious ceiling for a typical 8k-token local model.
+   */
+  maxContextChars: number;
 }
+
+// Per-provider conservative character budgets for the enrichment payload.
+// These are CHARACTER budgets, not token counts: local models often run an
+// 8k-token (~32k char) window, so 20000 chars leaves comfortable headroom
+// for the system prompt and the model's own output. Hosted providers (groq,
+// openai) carry much larger windows, so 50000 chars is safe there.
+const MAX_CONTEXT_CHARS: Record<AiProviderName, number> = {
+  local: 20000,
+  groq: 50000,
+  openai: 50000,
+};
+// Default used when no provider is configured. Matches the hosted ceiling so
+// deterministic-fallback callers that still read the field get a sane value.
+const DEFAULT_MAX_CONTEXT_CHARS = 50000;
 
 interface AiProviderConfig {
   provider: AiProviderName;
@@ -89,6 +111,7 @@ export function getAiCapabilities(): AiCapabilities {
       intakeEnrichment: !!config,
       postScaffoldReview: !!config,
     },
+    maxContextChars: config ? MAX_CONTEXT_CHARS[config.provider] : DEFAULT_MAX_CONTEXT_CHARS,
   };
 }
 

--- a/lib/planforge-orchestrator.ts
+++ b/lib/planforge-orchestrator.ts
@@ -24,7 +24,19 @@ export interface PlanforgeOrchestrationMetadata {
   aiUsed: boolean;
   provider: AiProviderName | null;
   model: string | null;
+  /**
+   * Set when one or more uploaded attachments were proportionally truncated
+   * to fit the provider's character budget before the enrichment call. Lets
+   * callers surface a non-silent notice instead of the user getting a quietly
+   * shortened (or, pre-budget, silently overflowed) prompt.
+   */
+  attachmentsTruncated?: boolean;
+  /** User-readable explanation, present only when attachmentsTruncated is true. */
+  notice?: string;
 }
+
+const ATTACHMENT_TRUNCATION_NOTICE =
+  "An uploaded attachment exceeded your AI provider context budget and was truncated.";
 
 interface IntakeEnrichment {
   nonFunctionalRequirements?: string[];
@@ -62,6 +74,10 @@ Rules:
 
 const ATTACHMENT_SENTINEL_OPEN = "--- BEGIN USER-UPLOADED DOCUMENT (UNTRUSTED) ---";
 const ATTACHMENT_SENTINEL_CLOSE = "--- END USER-UPLOADED DOCUMENT ---";
+// Appended on its own line inside a truncated block (between the sentinels)
+// so the model, and any human inspecting the prompt, can see the body was
+// cut to fit the provider budget rather than ending naturally.
+const ATTACHMENT_TRUNCATION_MARKER = "[truncated to fit the provider context budget]";
 
 function uniqueStrings(values: string[] | undefined): string[] | undefined {
   if (!values || values.length === 0) {
@@ -148,12 +164,143 @@ function attachmentsForPrompt(
   return out;
 }
 
+// Small reserve subtracted from the attachment budget so that the bytes the
+// truncation markers and the model's own response add do not nudge the prompt
+// back over the provider ceiling.
+const ATTACHMENT_BUDGET_SAFETY_MARGIN = 1000;
+
+/**
+ * Replace the body BETWEEN the sentinels of a wrapped attachment with a new
+ * body, keeping the sentinels themselves intact (the prompt-injection guard
+ * relies on them). Returns the original string unchanged if the sentinels are
+ * not both present, so a malformed entry can never strip its own guard.
+ */
+function rewrapAttachmentBody(wrapped: string, newBody: string): string {
+  const openIdx = wrapped.indexOf(ATTACHMENT_SENTINEL_OPEN);
+  const closeIdx = wrapped.lastIndexOf(ATTACHMENT_SENTINEL_CLOSE);
+  if (openIdx === -1 || closeIdx === -1 || closeIdx <= openIdx) {
+    return wrapped;
+  }
+  return `${ATTACHMENT_SENTINEL_OPEN}\n${newBody}\n${ATTACHMENT_SENTINEL_CLOSE}`;
+}
+
+/** Extract the inner body (between the sentinels) of a wrapped attachment. */
+function attachmentInnerBody(wrapped: string): string {
+  const openIdx = wrapped.indexOf(ATTACHMENT_SENTINEL_OPEN);
+  const closeIdx = wrapped.lastIndexOf(ATTACHMENT_SENTINEL_CLOSE);
+  if (openIdx === -1 || closeIdx === -1 || closeIdx <= openIdx) {
+    return wrapped;
+  }
+  return wrapped.slice(openIdx + ATTACHMENT_SENTINEL_OPEN.length, closeIdx).replace(/^\n|\n$/g, "");
+}
+
+/**
+ * Proportionally truncate attachment bodies so the whole additionalContext
+ * payload fits the provider character budget. The sentinels and the per-block
+ * truncation marker are preserved; only the user-uploaded inner body is cut.
+ *
+ * Returns the (possibly truncated) attachments and whether any truncation
+ * happened, so the caller can surface a non-silent notice instead of risking
+ * a quiet context-window overflow on a small-context model.
+ */
+function fitAttachmentsToBudget(
+  additionalContext: Array<{ name: string; inlineText: string }>,
+  maxContextChars: number,
+  restPromptChars: number
+): { attachments: Array<{ name: string; inlineText: string }>; truncated: boolean } {
+  if (additionalContext.length === 0) {
+    return { attachments: additionalContext, truncated: false };
+  }
+
+  // A non-finite or non-positive budget means we have no usable ceiling to
+  // enforce against (a misconfigured capability). Treat it as "no limit"
+  // rather than truncating everything to nothing: silently dropping all
+  // bodies would be the same zero-AI-benefit failure this feature exists to
+  // prevent.
+  if (!Number.isFinite(maxContextChars) || maxContextChars <= 0) {
+    return { attachments: additionalContext, truncated: false };
+  }
+
+  const totalAttachmentChars = additionalContext.reduce(
+    (sum, entry) => sum + entry.inlineText.length,
+    0
+  );
+  const attachmentBudget = maxContextChars - restPromptChars - ATTACHMENT_BUDGET_SAFETY_MARGIN;
+
+  // Already fits: leave the payload byte-identical to the untruncated path.
+  if (totalAttachmentChars <= attachmentBudget) {
+    return { attachments: additionalContext, truncated: false };
+  }
+
+  // Degenerate case: the base prompt alone is at or over budget, so there is
+  // no room for attachment bodies. Drop each body to a minimal stub (keeping
+  // sentinels + marker) rather than crashing or dividing by zero.
+  if (attachmentBudget <= 0) {
+    return {
+      attachments: additionalContext.map((entry) => ({
+        name: entry.name,
+        inlineText: rewrapAttachmentBody(entry.inlineText, ATTACHMENT_TRUNCATION_MARKER),
+      })),
+      truncated: true,
+    };
+  }
+
+  // Scale every body by the same factor so larger uploads cede more room. Each
+  // truncated block re-adds fixed overhead that the body budget must exclude:
+  // the BEGIN/END sentinels (re-added by rewrapAttachmentBody) and the marker
+  // line. Reserve both per attachment up front so the post-truncation total,
+  // which carries that overhead, stays inside attachmentBudget rather than
+  // overshooting by the sentinel width times the attachment count.
+  const markerOverheadPerAttachment = ATTACHMENT_TRUNCATION_MARKER.length + 1; // marker + its newline
+  const wrapperOverheadPerAttachment =
+    ATTACHMENT_SENTINEL_OPEN.length + ATTACHMENT_SENTINEL_CLOSE.length + 2; // both sentinels + their newlines
+  const bodyBudget = Math.max(
+    0,
+    attachmentBudget -
+      (markerOverheadPerAttachment + wrapperOverheadPerAttachment) * additionalContext.length
+  );
+  const totalBodyChars = additionalContext.reduce(
+    (sum, entry) => sum + attachmentInnerBody(entry.inlineText).length,
+    0
+  );
+  const scale = totalBodyChars > 0 ? bodyBudget / totalBodyChars : 0;
+
+  const attachments = additionalContext.map((entry) => {
+    const body = attachmentInnerBody(entry.inlineText);
+    const keep = Math.max(0, Math.floor(body.length * scale));
+    const truncatedBody = `${body.slice(0, keep)}\n${ATTACHMENT_TRUNCATION_MARKER}`;
+    return {
+      name: entry.name,
+      inlineText: rewrapAttachmentBody(entry.inlineText, truncatedBody),
+    };
+  });
+
+  return { attachments, truncated: true };
+}
+
 async function enrichIntake(
   input: ProjectInput,
   base: PlanforgePlanningInput,
   attachments?: Attachment[]
-): Promise<{ enrichment: IntakeEnrichment; provider: AiProviderName; model: string }> {
-  const additionalContext = attachmentsForPrompt(attachments);
+): Promise<{
+  enrichment: IntakeEnrichment;
+  provider: AiProviderName;
+  model: string;
+  attachmentsTruncated: boolean;
+}> {
+  const rawAdditionalContext = attachmentsForPrompt(attachments);
+
+  // Measure the rest of the prompt (everything except additionalContext) so
+  // the attachment budget is what is LEFT after the fixed scaffolding. Include
+  // the system prompt because it shares the same provider context window.
+  const restPromptChars =
+    ENRICHMENT_SYSTEM_PROMPT.length +
+    JSON.stringify({ projectInput: input, currentPlanforgeInput: base }, null, 2).length;
+
+  const { maxContextChars } = getAiCapabilities();
+  const { attachments: additionalContext, truncated: attachmentsTruncated } =
+    fitAttachmentsToBudget(rawAdditionalContext, maxContextChars, restPromptChars);
+
   // Sentinel safety relies on JSON-string encoding here: each attachment's
   // wrapped inlineText is serialized as a single quoted JSON value, so a
   // forged END sentinel inside an uploaded body cannot visually close the
@@ -182,6 +329,7 @@ async function enrichIntake(
     enrichment: result.data,
     provider: result.provider,
     model: result.model,
+    attachmentsTruncated,
   };
 }
 
@@ -208,7 +356,17 @@ export async function buildPlanforgeInput(
   }
 
   try {
-    const { enrichment, provider, model } = await enrichIntake(input, base, attachments);
+    const { enrichment, provider, model, attachmentsTruncated } = await enrichIntake(
+      input,
+      base,
+      attachments
+    );
+    if (attachmentsTruncated) {
+      console.warn(
+        "AI intake enrichment: uploaded attachment(s) exceeded the provider context budget" +
+          ` (${provider ?? "unknown"}) and were proportionally truncated to fit. ${ATTACHMENT_TRUNCATION_NOTICE}`
+      );
+    }
     return {
       planforgeInput: mergePlanforgeInput(base, enrichment),
       orchestration: {
@@ -216,6 +374,9 @@ export async function buildPlanforgeInput(
         aiUsed: true,
         provider,
         model,
+        ...(attachmentsTruncated
+          ? { attachmentsTruncated: true, notice: ATTACHMENT_TRUNCATION_NOTICE }
+          : {}),
       },
     };
   } catch (error) {

--- a/tests/integration/ai-assist-api.test.ts
+++ b/tests/integration/ai-assist-api.test.ts
@@ -29,6 +29,7 @@ describe("POST /api/ai-assist — mode dispatch & validation", () => {
         provider: "local",
         model: "qwen-local",
         features: { magicFill: true, intakeEnrichment: true },
+        maxContextChars: 50_000,
       }),
       generateStructuredJson:
         generateMock ??

--- a/tests/integration/planforge-orchestrator.test.ts
+++ b/tests/integration/planforge-orchestrator.test.ts
@@ -38,6 +38,7 @@ describe("planforge intake orchestration", () => {
           magicFill: true,
           intakeEnrichment: true,
         },
+        maxContextChars: 20_000,
       }),
       generateStructuredJson: vi.fn(async () => ({
         provider: "local",
@@ -81,6 +82,7 @@ describe("planforge intake orchestration", () => {
         provider: "local",
         model: "qwen-local",
         features: { magicFill: true, intakeEnrichment: true },
+        maxContextChars: 20_000,
       }),
       generateStructuredJson: generateMock,
     }));
@@ -140,6 +142,7 @@ describe("planforge intake orchestration", () => {
         provider: "local",
         model: "qwen-local",
         features: { magicFill: true, intakeEnrichment: true },
+        maxContextChars: 20_000,
       }),
       generateStructuredJson: generateMock,
     }));
@@ -190,6 +193,7 @@ describe("planforge intake orchestration", () => {
         provider: "local",
         model: "qwen-local",
         features: { magicFill: true, intakeEnrichment: true },
+        maxContextChars: 20_000,
       }),
       generateStructuredJson: generateMock,
     }));
@@ -256,6 +260,7 @@ describe("planforge intake orchestration", () => {
         provider: "local",
         model: "qwen-local",
         features: { magicFill: true, intakeEnrichment: true },
+        maxContextChars: 20_000,
       }),
       generateStructuredJson: generateMock,
     }));
@@ -290,6 +295,7 @@ describe("planforge intake orchestration", () => {
         provider: "local",
         model: "qwen-local",
         features: { magicFill: true, intakeEnrichment: true },
+        maxContextChars: 20_000,
       }),
       generateStructuredJson: generateMock,
     }));
@@ -321,5 +327,166 @@ describe("planforge intake orchestration", () => {
     // None of the entries qualified, so additionalContext stays absent
     // — matches the back-compat path above.
     expect(parsed).not.toHaveProperty("additionalContext");
+  });
+
+  it("leaves under-budget attachments untouched (no truncation flag)", async () => {
+    const generateMock = vi.fn(async () => ({
+      provider: "local" as const,
+      model: "qwen-local",
+      data: {},
+    }));
+    vi.doMock("@/lib/ai-provider", () => ({
+      getAiCapabilities: () => ({
+        enabled: true,
+        provider: "local",
+        model: "qwen-local",
+        features: { magicFill: true, intakeEnrichment: true, postScaffoldReview: true },
+        // Generous budget: a tiny attachment must not be touched.
+        maxContextChars: 50_000,
+      }),
+      generateStructuredJson: generateMock,
+    }));
+
+    const { buildPlanforgeInput } = await import("../../lib/planforge-orchestrator");
+
+    const body = "## Compliance\n\nMust comply with HIPAA for patient data.";
+    const result = await buildPlanforgeInput(
+      {
+        projectName: "demo-app",
+        summary: "An internal portal.",
+        features: ["dashboard"],
+        constraints: [],
+        targetUsers: ["staff"],
+      },
+      [{ name: "arc42.md", mimeType: "text/markdown", tier: "text", inlineText: body }]
+    );
+
+    const [, userPrompt] = generateMock.mock.calls[0] as unknown as [string, string];
+    const parsed = JSON.parse(userPrompt) as {
+      additionalContext: Array<{ name: string; inlineText: string }>;
+    };
+    // Byte-identical to the untruncated wrap: no marker, no cuts.
+    expect(parsed.additionalContext[0].inlineText).toBe(
+      "--- BEGIN USER-UPLOADED DOCUMENT (UNTRUSTED) ---\n" +
+        body +
+        "\n--- END USER-UPLOADED DOCUMENT ---"
+    );
+    expect(parsed.additionalContext[0].inlineText).not.toContain("truncated to fit");
+    // No truncation occurred → optional metadata stays absent (back-compat).
+    expect(result.orchestration.attachmentsTruncated).toBeUndefined();
+    expect(result.orchestration.notice).toBeUndefined();
+  });
+
+  it("proportionally truncates over-budget attachments while preserving sentinels and setting the notice", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const generateMock = vi.fn(async () => ({
+      provider: "local" as const,
+      model: "qwen-local",
+      data: {},
+    }));
+    // Tight budget so the attachments must be cut.
+    const maxContextChars = 4_000;
+    vi.doMock("@/lib/ai-provider", () => ({
+      getAiCapabilities: () => ({
+        enabled: true,
+        provider: "local",
+        model: "qwen-local",
+        features: { magicFill: true, intakeEnrichment: true, postScaffoldReview: true },
+        maxContextChars,
+      }),
+      generateStructuredJson: generateMock,
+    }));
+
+    const { buildPlanforgeInput } = await import("../../lib/planforge-orchestrator");
+
+    // Two attachments, one twice the size of the other → proportional cut.
+    const bigBody = "A".repeat(6_000);
+    const smallBody = "B".repeat(3_000);
+
+    const result = await buildPlanforgeInput(
+      {
+        projectName: "demo-app",
+        summary: "An internal portal.",
+        features: ["dashboard"],
+        constraints: [],
+        targetUsers: ["staff"],
+      },
+      [
+        { name: "big.md", mimeType: "text/markdown", tier: "text", inlineText: bigBody },
+        { name: "small.md", mimeType: "text/markdown", tier: "text", inlineText: smallBody },
+      ]
+    );
+
+    const [, userPrompt] = generateMock.mock.calls[0] as unknown as [string, string];
+    const parsed = JSON.parse(userPrompt) as {
+      additionalContext: Array<{ name: string; inlineText: string }>;
+    };
+
+    // Both attachments were cut and carry the marker on their own line.
+    for (const entry of parsed.additionalContext) {
+      expect(entry.inlineText).toContain("[truncated to fit the provider context budget]");
+      // Sentinels are NEVER stripped: the injection guard must survive.
+      expect(entry.inlineText.startsWith("--- BEGIN USER-UPLOADED DOCUMENT (UNTRUSTED) ---\n")).toBe(
+        true
+      );
+      expect(entry.inlineText.endsWith("\n--- END USER-UPLOADED DOCUMENT ---")).toBe(true);
+    }
+
+    // The whole enrichment user prompt the model receives now fits inside the
+    // provider window. This is the invariant the budget actually enforces:
+    // it accounts for the projectInput/base scaffolding, not just the
+    // attachment bytes, so a regression that stopped subtracting the rest of
+    // the prompt would push userPrompt past maxContextChars and fail here.
+    expect(userPrompt.length).toBeLessThanOrEqual(maxContextChars);
+    const totalAttachmentChars = parsed.additionalContext.reduce(
+      (sum, e) => sum + e.inlineText.length,
+      0
+    );
+    expect(totalAttachmentChars).toBeLessThanOrEqual(maxContextChars);
+
+    // Both bodies were cut down from their originals.
+    const bigEntry = parsed.additionalContext.find((e) => e.name === "big.md")!;
+    const smallEntry = parsed.additionalContext.find((e) => e.name === "small.md")!;
+    expect(bigEntry.inlineText.length).toBeLessThan(bigBody.length);
+    expect(smallEntry.inlineText.length).toBeLessThan(smallBody.length);
+    // Proportional: the larger upload keeps a longer kept-body than the smaller one.
+    expect(bigEntry.inlineText.length).toBeGreaterThan(smallEntry.inlineText.length);
+
+    // Non-silent: metadata flag + user-readable notice + a console warning.
+    expect(result.orchestration.attachmentsTruncated).toBe(true);
+    expect(result.orchestration.notice).toMatch(/exceeded your AI provider context budget/);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("falls back to deterministic intake when the AI call throws (fallback path intact)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.doMock("@/lib/ai-provider", () => ({
+      getAiCapabilities: () => ({
+        enabled: true,
+        provider: "local",
+        model: "qwen-local",
+        features: { magicFill: true, intakeEnrichment: true, postScaffoldReview: true },
+        maxContextChars: 20_000,
+      }),
+      generateStructuredJson: vi.fn(async () => {
+        throw new Error("provider exploded");
+      }),
+    }));
+
+    const { buildPlanforgeInput } = await import("../../lib/planforge-orchestrator");
+
+    const result = await buildPlanforgeInput({
+      projectName: "demo-app",
+      summary: "An internal portal.",
+      features: ["dashboard"],
+      constraints: ["TypeScript only"],
+      targetUsers: ["staff"],
+    });
+
+    expect(result.orchestration.mode).toBe("deterministic");
+    expect(result.orchestration.aiUsed).toBe(false);
+    // Genuine AI errors still produce the deterministic mapping, not a crash.
+    expect(result.planforgeInput.constraints).toEqual(["TypeScript only"]);
+    expect(warnSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

Adds a per-provider character budget (`maxContextChars`) to the AI intake-enrichment call so a large uploaded attachment is proportionally truncated to fit the provider's context window instead of silently overflowing a small-context local model (qwen/llama 4k/8k) or being dropped for zero AI benefit.

## Why

With the 50k-char cap, the enrichment prompt could carry roughly 12.5k input tokens. That fits hosted models but overflows small-context local providers, where the try/catch fallback silently reverts to deterministic intake: the user paid the upload time for nothing, with no visibility. Flagged by the v0.1d review subagent (finding D3).

## Changes

- `lib/ai-provider.ts`: `AiCapabilities` gains a required `maxContextChars` (a character budget, not tokens): local 20000, hosted 50000, default 50000.
- `lib/planforge-orchestrator.ts`: `enrichIntake` measures the fixed prompt scaffolding, derives an attachment budget, and proportionally truncates each attachment's inner body to fit, preserving the BEGIN/END injection sentinels and appending a truncation marker. Surfaced non-silently via new optional `orchestration.attachmentsTruncated` / `notice` plus a warning. The deterministic fallback for genuine AI errors is unchanged.
- Tests: under-budget (untouched), over-budget (proportional truncation, sentinels preserved, the whole prompt fits the window, flag + notice set), and the fallback path. All 7 existing `getAiCapabilities` mocks updated to the new shape.

## Verification

- `npm run lint` clean (2 pre-existing unrelated warnings), `tsc --noEmit` exit 0, `vitest` 85/85 (+3 new).
- Adversarial review subagent: pass, 0 blocking. Two small in-scope nits (budget overshoot at high attachment counts; loose test bound) fixed inline before merge.

Refs: agent-tasks bb8d1687