### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-01
+
 ### Added
 
-- **Per-provider character budget for the intake-enrichment call.** A new `maxContextChars` capability (local 20000, hosted 50000) drives proportional truncation of large uploaded attachment bodies so the enrichment prompt no longer risks a silent context-window overflow on small-context local models; truncation keeps the injection sentinels intact and is surfaced non-silently via `orchestration.attachmentsTruncated`/`notice` and a warning.
+- **Per-provider character budget for the intake-enrichment call.** A new `maxContextChars` capability (local 20000, hosted 50000) drives proportional truncation of large uploaded attachment bodies so the enrichment prompt no longer risks a silent context-window overflow on small-context local models; truncation keeps the injection sentinels intact and is surfaced non-silently via `orchestration.attachmentsTruncated`/`notice` and a warning (#75).
+
+### Changed
+
+- **Attachments are authoritative without overriding explicit intake choices.** The enrichment flow now treats attachment content as authoritative evidence, but stops it from silently overriding intake fields the user set explicitly (#74).
+- Honor the `.planforge/docs` relocation in the output-layout review denylist so relocated docs are excluded from review as intended (#73).
+
+### Security
+
+- **Close IDOR, add auth, and stop a PAT leak on the legacy routes (HIGH audit).** Tightens authorization on the legacy routes, adds missing auth checks, and stops a personal access token from leaking in responses (#71).
+- **Guard the legacy publish route against `sessionId` path traversal**, rejecting crafted identifiers before they reach the filesystem (#70).
+- Bump `axios` to 1.16.1 to patch CVE-2026-44489 (#72).
 
 ## [0.3.0] - 2026-05-28
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "project-forge",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "project-forge",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "bcryptjs": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-forge",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Release v0.4.0

Rolls up all merged work since v0.3.0. No source changes in this PR: it promotes the `[Unreleased]` changelog to `[0.4.0]` and bumps the version.

### Highlights

- **Added:** a per-provider `maxContextChars` budget that proportionally truncates oversized attachment bodies so the enrichment prompt fits small-context local models, surfaced non-silently (#75).
- **Changed:** attachments treated as authoritative without overriding explicit intake choices (#74); the output-layout review denylist now honors the `.planforge/docs` relocation (#73).
- **Security:** legacy-route IDOR/auth/PAT-leak HIGH-audit fixes (#71), a `sessionId` path-traversal guard on the legacy publish route (#70), and axios bumped to 1.16.1 for CVE-2026-44489 (#72).

Version bumped to 0.4.0 in `package.json` and `package-lock.json`. Merging this and pushing tag `v0.4.0` triggers the tag-driven release workflow.

Refs: agent-tasks 8095881a