### PR TITLE
feat(planforge): tolerate planforge index without a handoff block

### DIFF
--- a/lib/planforge-output.ts
+++ b/lib/planforge-output.ts
@@ -6,12 +6,14 @@ type PathMap = Record<string, string>;
 
 interface PlanforgeIndex {
   generatedBy?: string;
-  rootFiles?: PathMap;
-  directories?: PathMap;
-  planning?: PathMap;
+  rootFiles: PathMap;
+  directories: PathMap;
+  planning: PathMap;
+  exports: PathMap;
+  ai: PathMap;
+  // Optional: agent-planforge drops this block once the runner/handoff vision
+  // is removed (Phase 3). Every other block above is required by isPlanforgeIndex.
   handoff?: PathMap;
-  exports?: PathMap;
-  ai?: PathMap;
 }
 
 export interface ResolvedPlanforgeOutputPaths {
@@ -21,8 +23,6 @@ export interface ResolvedPlanforgeOutputPaths {
   architecturePath: string;
   scaffoldkitInputPath: string;
   planOutputPath: string;
-  handoffManifestPath: string;
-  runnerContractPath: string;
 }
 
 const PLANNING_BASELINE: ScaffoldPreview = {
@@ -57,7 +57,10 @@ function isPlanforgeIndex(value: unknown): value is PlanforgeIndex {
     isPathMap(candidate.rootFiles) &&
     isPathMap(candidate.directories) &&
     isPathMap(candidate.planning) &&
-    isPathMap(candidate.handoff) &&
+    // handoff is optional: agent-planforge stopped emitting the runner/handoff
+    // block (Phase 3). Accept an index with no handoff key, but still validate
+    // it when present so a malformed block is rejected.
+    (candidate.handoff === undefined || isPathMap(candidate.handoff)) &&
     isPathMap(candidate.exports) &&
     isPathMap(candidate.ai)
   );
@@ -89,8 +92,6 @@ export async function resolvePlanforgeOutputPaths(tempDir: string): Promise<Reso
       architecturePath: path.join(tempDir, "architecture-overview.md"),
       scaffoldkitInputPath: path.join(tempDir, "scaffoldkit-input.json"),
       planOutputPath: path.join(tempDir, "plan-output.json"),
-      handoffManifestPath: path.join(tempDir, "handoff-manifest.json"),
-      runnerContractPath: path.join(tempDir, "runner-contract.json"),
     };
   }
 
@@ -112,16 +113,6 @@ export async function resolvePlanforgeOutputPaths(tempDir: string): Promise<Reso
       tempDir,
       index.planning?.planOutput,
       path.join(tempDir, "plan-output.json")
-    ),
-    handoffManifestPath: resolveArtifactPath(
-      tempDir,
-      index.handoff?.manifest,
-      path.join(tempDir, "handoff-manifest.json")
-    ),
-    runnerContractPath: resolveArtifactPath(
-      tempDir,
-      index.handoff?.runnerContract,
-      path.join(tempDir, "runner-contract.json")
     ),
   };
 }

--- a/lib/post-scaffold-review.ts
+++ b/lib/post-scaffold-review.ts
@@ -105,6 +105,9 @@ const PLANFORGE_TOP_LEVEL_PATHS = new Set([
   "adrs",
   "exports",
   "governance",
+  // Back-compat: agent-planforge stops emitting handoff/ once the runner vision
+  // is removed (Phase 3). Retained so older flat tarballs still match; safe to
+  // drop after the migration window.
   "handoff",
   "planning",
   "prompts",
@@ -462,6 +465,14 @@ Confirm that the selected scaffold baseline is appropriate for this project befo
   return { path: filePath, contents };
 }
 
+// post-scaffold-review is project-forge's own assessment artifact, not part of
+// the planforge handoff bundle. It is written under .planforge/ (a planner-side
+// namespace) so it no longer depends on the handoff/ directory, which
+// agent-planforge is removing in Phase 3.
+function planforgeStateDir(tempDir: string): string {
+  return path.join(tempDir, ".planforge");
+}
+
 export async function runPostScaffoldReview(tempDir: string): Promise<PostScaffoldReview> {
   const artifacts = await resolvePlanforgeOutputPaths(tempDir);
   const scaffoldInput = await readJsonFile<ScaffoldkitInput>(artifacts.scaffoldkitInputPath);
@@ -525,13 +536,13 @@ export async function runPostScaffoldReview(tempDir: string): Promise<PostScaffo
     ...(aiAssessment ? { aiAssessment } : {}),
   };
 
-  const handoffDir = path.dirname(artifacts.handoffManifestPath);
-  await fs.mkdir(handoffDir, { recursive: true });
+  const reviewDir = planforgeStateDir(tempDir);
+  await fs.mkdir(reviewDir, { recursive: true });
   await fs.writeFile(
-    path.join(handoffDir, "post-scaffold-review.json"),
+    path.join(reviewDir, "post-scaffold-review.json"),
     `${JSON.stringify(review, null, 2)}\n`
   );
-  await fs.writeFile(path.join(handoffDir, "post-scaffold-review.md"), renderReviewMarkdown(review));
+  await fs.writeFile(path.join(reviewDir, "post-scaffold-review.md"), renderReviewMarkdown(review));
 
   const followUpTask = createFollowUpTask(review);
   if (followUpTask) {
@@ -542,19 +553,18 @@ export async function runPostScaffoldReview(tempDir: string): Promise<PostScaffo
       mustCompleteBeforeWave: "wave-1",
     };
     await fs.writeFile(
-      path.join(handoffDir, "post-scaffold-review.json"),
+      path.join(reviewDir, "post-scaffold-review.json"),
       `${JSON.stringify(review, null, 2)}\n`
     );
-    await fs.writeFile(path.join(handoffDir, "post-scaffold-review.md"), renderReviewMarkdown(review));
+    await fs.writeFile(path.join(reviewDir, "post-scaffold-review.md"), renderReviewMarkdown(review));
   }
 
   return review;
 }
 
 export async function readPostScaffoldReview(tempDir: string): Promise<PostScaffoldReview | null> {
-  const artifacts = await resolvePlanforgeOutputPaths(tempDir);
   return readJsonFile<PostScaffoldReview>(
-    path.join(path.dirname(artifacts.handoffManifestPath), "post-scaffold-review.json")
+    path.join(planforgeStateDir(tempDir), "post-scaffold-review.json")
   );
 }
 

--- a/tests/integration/planforge-output.test.ts
+++ b/tests/integration/planforge-output.test.ts
@@ -102,9 +102,6 @@ describe("planforge output resolver", () => {
     expect(resolved.planOutputPath).toBe(
       path.join(tempDir, "planning", "plan-output.json")
     );
-    expect(resolved.handoffManifestPath).toBe(
-      path.join(tempDir, "handoff", "manifest.json")
-    );
   });
 
   it("falls back to legacy root paths when no index is present", async () => {
@@ -118,9 +115,6 @@ describe("planforge output resolver", () => {
       path.join(tempDir, "scaffoldkit-input.json")
     );
     expect(resolved.planOutputPath).toBe(path.join(tempDir, "plan-output.json"));
-    expect(resolved.handoffManifestPath).toBe(
-      path.join(tempDir, "handoff-manifest.json")
-    );
   });
 
   it("reads scaffold preview from the indexed exports path", async () => {
@@ -195,5 +189,79 @@ describe("planforge output resolver", () => {
     const preview = await readScaffoldPreview(tempDir);
 
     expect(preview.status).toBe("planning-baseline");
+  });
+
+  it("treats an index without a handoff block as valid (post-Phase-3 layout)", async () => {
+    const tempDir = await makeTempDir();
+    tempDirs.push(tempDir);
+
+    await fs.mkdir(path.join(tempDir, ".planforge", "exports"), { recursive: true });
+    // No handoff block, exports/plan-output relocated under .planforge/ — the
+    // shape agent-planforge emits once the runner/handoff vision is removed.
+    await fs.writeFile(
+      path.join(tempDir, "planforge-index.json"),
+      JSON.stringify(
+        {
+          version: "2.0",
+          generatedBy: "agent-planforge",
+          rootFiles: {
+            agents: "AGENTS.md",
+            architecture: ".planforge/docs/architecture-overview.md",
+          },
+          directories: { ai: ".ai", tasks: "tasks" },
+          planning: { planOutput: ".planforge/planning/plan-output.json" },
+          exports: { scaffoldkit: ".planforge/exports/scaffoldkit-input.json" },
+          ai: { agents: ".ai/AGENTS.md" },
+        },
+        null,
+        2
+      )
+    );
+
+    const resolved = await resolvePlanforgeOutputPaths(tempDir);
+
+    // The missing handoff block must NOT invalidate the index and silently
+    // fall back to flat-layout defaults (which would mis-resolve scaffoldkit
+    // input and degrade every scaffold-fit check to PLANNING_BASELINE).
+    expect(resolved.hasIndex).toBe(true);
+    expect(resolved.scaffoldkitInputPath).toBe(
+      path.join(tempDir, ".planforge", "exports", "scaffoldkit-input.json")
+    );
+    expect(resolved.planOutputPath).toBe(
+      path.join(tempDir, ".planforge", "planning", "plan-output.json")
+    );
+  });
+
+  it("rejects an index whose handoff block is present but malformed", async () => {
+    // The optional-handoff branch must tolerate an ABSENT handoff only — a
+    // present-but-broken handoff still invalidates the whole index (otherwise a
+    // malformed block would slip through as valid).
+    const malformedHandoffs: unknown[] = ["not-a-map", { manifest: "" }, { manifest: 123 }];
+
+    for (const handoff of malformedHandoffs) {
+      const tempDir = await makeTempDir();
+      tempDirs.push(tempDir);
+
+      await fs.writeFile(
+        path.join(tempDir, "planforge-index.json"),
+        JSON.stringify(
+          {
+            generatedBy: "agent-planforge",
+            rootFiles: { agents: "AGENTS.md", architecture: "architecture-overview.md" },
+            directories: { ai: ".ai", tasks: "tasks" },
+            planning: { planOutput: "planning/plan-output.json" },
+            handoff,
+            exports: { scaffoldkit: "exports/scaffoldkit-input.json" },
+            ai: { agents: ".ai/AGENTS.md" },
+          },
+          null,
+          2
+        )
+      );
+
+      const resolved = await resolvePlanforgeOutputPaths(tempDir);
+
+      expect(resolved.hasIndex).toBe(false);
+    }
   });
 });

--- a/tests/integration/post-scaffold-review.test.ts
+++ b/tests/integration/post-scaffold-review.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { __internal } from "../../lib/post-scaffold-review";
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import {
+  __internal,
+  readPostScaffoldReview,
+  runPostScaffoldReview,
+} from "../../lib/post-scaffold-review";
 
 describe("post-scaffold review helpers", () => {
   it("flags weak blueprint confidence as review-recommended", () => {
@@ -73,5 +80,60 @@ describe("post-scaffold review helpers", () => {
 
     expect(preview?.mustReviewBeforeImplementation).toBe(true);
     expect(preview?.followUpTaskPath).toBe("tasks/900-blueprint-fit-review.md");
+  });
+});
+
+describe("post-scaffold review artifact relocation", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  it("writes the review under .planforge/ and reads it back (no handoff/ dependency)", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "project-forge-review-"));
+    tempDirs.push(tempDir);
+
+    // tasks/ always exists in a real planforge output tree; the weak-confidence
+    // path writes a tasks/900 follow-up into it.
+    await fs.mkdir(path.join(tempDir, "tasks"), { recursive: true });
+
+    // Flat-layout scaffoldkit input (no index): resolvePlanforgeOutputPaths
+    // falls back to <tempDir>/scaffoldkit-input.json.
+    await fs.writeFile(
+      path.join(tempDir, "scaffoldkit-input.json"),
+      JSON.stringify(
+        {
+          projectName: "demo",
+          blueprint: "rest-api",
+          blueprintConfidence: "weak",
+          agentMustCreateStructure: true,
+        },
+        null,
+        2
+      )
+    );
+
+    const written = await runPostScaffoldReview(tempDir);
+
+    // Artifacts land under .planforge/, not the (removed) handoff/ dir.
+    await expect(
+      fs.access(path.join(tempDir, ".planforge", "post-scaffold-review.json"))
+    ).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(tempDir, ".planforge", "post-scaffold-review.md"))
+    ).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(tempDir, "handoff", "post-scaffold-review.json"))
+    ).rejects.toThrow();
+
+    // Round-trip: the sole reader resolves the same .planforge/ location.
+    const readBack = await readPostScaffoldReview(tempDir);
+    expect(readBack).not.toBeNull();
+    expect(readBack?.verdict.status).toBe(written.verdict.status);
+    expect(readBack?.blueprint.selected).toBe("rest-api");
   });
 });


### PR DESCRIPTION
## What
project-forge now tolerates a `planforge-index.json` that has no top-level `handoff` block, in preparation for agent-planforge dropping its runner/handoff fleet artifacts (Phase 3, task a9311d34).

## Why
`isPlanforgeIndex` hard-required `handoff` to be a PathMap. Once planforge stops emitting it, `isPathMap(undefined)` returns false, `readPlanforgeIndex` returns null, and every path falls back to the flat layout. The downstream effect is silent: `readScaffoldPreview` mis-resolves `scaffoldkit-input.json` and returns `PLANNING_BASELINE` for every project, with no error or log. This PR removes that trap so the planforge change can ship afterwards (expand-then-contract).

## Changes
- `isPlanforgeIndex`: the `handoff` block is optional now (absent is valid; a present-but-malformed block is still rejected).
- Removed the dead `handoffManifestPath` / `runnerContractPath` resolver fields (resolved but never read).
- Moved `post-scaffold-review.json` / `.md` off the disappearing `handoff/` dir to `.planforge/`, via a dedicated `planforgeStateDir` helper.
- Tightened the `PlanforgeIndex` type so required blocks are not marked optional.

## Tests
- New: index without a handoff block stays valid (would fail against pre-change code).
- New: a present-but-malformed handoff block is rejected.
- New: post-scaffold-review `.planforge/` write then read round-trip.
- Full suite 88/88, tsc + eslint clean.

## Interlock / follow-up
- Ships BEFORE agent-planforge W2 (which drops the handoff block). Backward compatible, safe standalone.
- The `.planforge/` side-channel is not yet excluded from the published repo: publish is `git add -A` with no `.planforge` denylist, and planforge emits no `.gitignore`. Making `.planforge/` non-committed is agent-planforge W2 scope (emit a `.gitignore`).

Refs: agent-planforge a9311d34, verification workflow wf_a5e2cf97-c4e