### PR TITLE
feat(publish): keep planforge generation-only artifacts out of the deliverable

### DIFF
--- a/app/api/publish/route.ts
+++ b/app/api/publish/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import * as fs from "fs/promises";
 import * as path from "path";
+import { excludePlanforgeArtifactsFromPublish } from "@/lib/planforge-output";
 import type { PublishResponse, ErrorResponse } from "../../../lib/types";
 import { runCommand } from "@/lib/subprocess";
 import { SESSION_UUID_RE, readForgeMeta, isSessionExpired } from "@/lib/v1-shared";
@@ -191,6 +192,7 @@ async function runGitCommands(
   await fs.rm(path.join(repoPath, ".forge-published"), { force: true }).catch(() => {});
 
   await git(["init", "-b", "main"]);
+  await excludePlanforgeArtifactsFromPublish(repoPath);
   await git(["config", "user.email", "forge@project-forge.dev"]);
   await git(["config", "user.name", "project-forge"]);
   await git(["add", "-A"]);

--- a/app/api/v1/projects/route.ts
+++ b/app/api/v1/projects/route.ts
@@ -3,6 +3,7 @@ import { validateApiToken, checkRateLimit, prisma } from "@/lib/db";
 import { randomUUID } from "crypto";
 import * as fs from "fs/promises";
 import * as path from "path";
+import { excludePlanforgeArtifactsFromPublish } from "@/lib/planforge-output";
 import { buildPlanforgeInput } from "@/lib/planforge-orchestrator";
 import { runPlanforgeViaHttp, PlanforgeClientError, assertScaffoldkitRan } from "@/lib/planforge-client";
 import { runPostScaffoldReview } from "@/lib/post-scaffold-review";
@@ -289,6 +290,7 @@ async function createAndPushRepo(
     runCommand("git", args, { cwd: projectDir, timeoutMs });
 
   await git(["init"]);
+  await excludePlanforgeArtifactsFromPublish(projectDir);
   await git(["config", "user.email", "forge@project-forge.dev"]);
   await git(["config", "user.name", "project-forge"]);
   await git(["add", "."]);

--- a/app/api/v1/publish/route.ts
+++ b/app/api/v1/publish/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { validateApiToken, checkRateLimit, prisma } from "@/lib/db";
 import * as fs from "fs/promises";
 import * as path from "path";
+import { excludePlanforgeArtifactsFromPublish } from "@/lib/planforge-output";
 import type { ErrorResponse } from "@/lib/types";
 import { summarizePublishError } from "@/lib/publish-error";
 import { runCommand } from "@/lib/subprocess";
@@ -163,6 +164,7 @@ async function createAndPushRepo(projectDir: string, repoName: string, githubPat
     runCommand("git", args, { cwd: projectDir, timeoutMs, env: { ...process.env, ...gitEnv } });
 
   await git(["init", "-b", "main"]);
+  await excludePlanforgeArtifactsFromPublish(projectDir);
   await git(["config", "user.email", "forge@project-forge.dev"]);
   await git(["config", "user.name", "project-forge"]);
   await git(["add", "-A"]);

--- a/lib/planforge-output.ts
+++ b/lib/planforge-output.ts
@@ -136,3 +136,42 @@ export async function readScaffoldPreview(tempDir: string): Promise<ScaffoldPrev
     return PLANNING_BASELINE;
   }
 }
+
+// Generation-only planforge artifacts: downstream tools read these at
+// generation time (planforge resume reads plan-output.json; scaffoldkit and
+// project-forge read scaffoldkit-input.json before publish), but they have no
+// value once committed into the deliverable. They are kept out of the published
+// repo via .git/info/exclude, which is local to the temp clone and so never
+// collides with scaffoldkit's own committed root .gitignore.
+export const PLANFORGE_PUBLISH_EXCLUDES = [
+  "/planning/plan-output.json",
+  "/exports/scaffoldkit-input.json",
+];
+
+export async function excludePlanforgeArtifactsFromPublish(projectDir: string): Promise<void> {
+  // Derive the actual artifact locations from the generated index so the
+  // exclude list tracks whatever layout planforge emits (e.g. a future move
+  // under .planforge/) instead of drifting from hardcoded paths. Fall back to
+  // the current default paths only when no index is present.
+  const resolved = await resolvePlanforgeOutputPaths(projectDir);
+  const toPattern = (absolutePath: string) =>
+    `/${path.relative(projectDir, absolutePath).split(path.sep).join("/")}`;
+  const excludes = resolved.hasIndex
+    ? [toPattern(resolved.planOutputPath), toPattern(resolved.scaffoldkitInputPath)]
+    : PLANFORGE_PUBLISH_EXCLUDES;
+
+  const excludePath = path.join(projectDir, ".git", "info", "exclude");
+  await fs.mkdir(path.dirname(excludePath), { recursive: true });
+  const existing = await fs.readFile(excludePath, "utf-8").catch(() => "");
+  const block = [
+    "# planforge generation-only artifacts (kept out of the deliverable)",
+    ...excludes,
+  ].join("\n");
+  if (existing.includes(block)) {
+    return;
+  }
+  const next = existing.trim()
+    ? `${existing.replace(/\n+$/, "")}\n${block}\n`
+    : `${block}\n`;
+  await fs.writeFile(excludePath, next);
+}

--- a/tests/integration/planforge-output.test.ts
+++ b/tests/integration/planforge-output.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
 import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
 import {
+  excludePlanforgeArtifactsFromPublish,
   readScaffoldPreview,
   resolvePlanforgeOutputPaths,
 } from "../../lib/planforge-output";
@@ -10,6 +12,100 @@ import {
 async function makeTempDir(): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), "project-forge-planforge-"));
 }
+
+describe("planforge publish exclusion", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  it("keeps generation-only artifacts out of git while staging the rest", async () => {
+    const tempDir = await makeTempDir();
+    tempDirs.push(tempDir);
+
+    await fs.mkdir(path.join(tempDir, "planning"), { recursive: true });
+    await fs.mkdir(path.join(tempDir, "exports"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, "planning", "plan-output.json"), "{}\n");
+    await fs.writeFile(path.join(tempDir, "exports", "scaffoldkit-input.json"), "{}\n");
+    await fs.writeFile(path.join(tempDir, "planning", "structured-input.json"), "{}\n");
+    await fs.writeFile(path.join(tempDir, "README.md"), "# demo\n");
+
+    const git = (args: string[]) =>
+      execFileSync("git", args, { cwd: tempDir, stdio: "pipe" });
+    git(["init"]);
+    git(["config", "user.email", "t@example.com"]);
+    git(["config", "user.name", "t"]);
+
+    await excludePlanforgeArtifactsFromPublish(tempDir);
+    git(["add", "-A"]);
+
+    const staged = execFileSync("git", ["ls-files"], {
+      cwd: tempDir,
+      encoding: "utf-8",
+    })
+      .split("\n")
+      .filter(Boolean);
+
+    expect(staged).not.toContain("planning/plan-output.json");
+    expect(staged).not.toContain("exports/scaffoldkit-input.json");
+    // Unrelated and not-yet-excluded files are still committed.
+    expect(staged).toContain("README.md");
+    expect(staged).toContain("planning/structured-input.json");
+  });
+
+  it("derives exclude paths from the index when artifacts are relocated", async () => {
+    const tempDir = await makeTempDir();
+    tempDirs.push(tempDir);
+
+    // A future .planforge/-relocated layout: the exclude must follow the index,
+    // not hardcoded paths, or the artifacts silently leak back in.
+    await fs.mkdir(path.join(tempDir, ".planforge", "planning"), { recursive: true });
+    await fs.mkdir(path.join(tempDir, ".planforge", "exports"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, ".planforge", "planning", "plan-output.json"), "{}\n");
+    await fs.writeFile(path.join(tempDir, ".planforge", "exports", "scaffoldkit-input.json"), "{}\n");
+    await fs.writeFile(path.join(tempDir, "README.md"), "# demo\n");
+    await fs.writeFile(
+      path.join(tempDir, "planforge-index.json"),
+      JSON.stringify(
+        {
+          generatedBy: "agent-planforge",
+          rootFiles: { agents: "AGENTS.md" },
+          directories: { ai: ".ai", tasks: "tasks" },
+          planning: { planOutput: ".planforge/planning/plan-output.json" },
+          exports: { scaffoldkit: ".planforge/exports/scaffoldkit-input.json" },
+          ai: { agents: ".ai/AGENTS.md" },
+        },
+        null,
+        2
+      )
+    );
+
+    const git = (args: string[]) =>
+      execFileSync("git", args, { cwd: tempDir, stdio: "pipe" });
+    git(["init"]);
+    git(["config", "user.email", "t@example.com"]);
+    git(["config", "user.name", "t"]);
+
+    await excludePlanforgeArtifactsFromPublish(tempDir);
+    git(["add", "-A"]);
+
+    const staged = execFileSync("git", ["ls-files"], {
+      cwd: tempDir,
+      encoding: "utf-8",
+    })
+      .split("\n")
+      .filter(Boolean);
+
+    expect(staged).not.toContain(".planforge/planning/plan-output.json");
+    expect(staged).not.toContain(".planforge/exports/scaffoldkit-input.json");
+    expect(staged).toContain("README.md");
+    expect(staged).toContain("planforge-index.json");
+  });
+});
 
 describe("planforge output resolver", () => {
   const tempDirs: string[] = [];


### PR DESCRIPTION
## What
`planning/plan-output.json` (the large machine plan dump) and `exports/scaffoldkit-input.json` (the scaffoldkit tool handoff) are read at generation time but have no value committed into the published repo. This excludes them at publish via `.git/info/exclude`, written after `git init` and before `git add` in all three publish paths (`app/api/v1/publish`, `app/api/publish`, `app/api/v1/projects`).

## Why this mechanism (not a generated .gitignore)
scaffoldkit emits its own root `.gitignore` per blueprint and runs after planforge with `--overwrite`, so a generated `.gitignore` would be clobbered. `.git/info/exclude` is local to the temp clone, so it never collides with any committed `.gitignore`. `.planforge/` could not be ignored wholesale either, since it holds visible deliverable content (`.planforge/docs`, `.planforge/tooling`). The publisher is the clean single point. (Phase 3 W2b; operator decision: project-forge-side exclusion.)

## Details
- The exclude patterns are derived from the generated `planforge-index.json` (via `resolvePlanforgeOutputPaths`), so they track whatever layout planforge emits instead of drifting from hardcoded paths; the default paths are the no-index fallback. The write is idempotent.
- The files stay on disk for generation-time consumers (project-forge reads `scaffoldkit-input.json` for the scaffold-fit check, planforge resume reads `plan-output.json`); only the commit is affected.

## Tests
- New: real `git init` + helper + `git add`, asserting `git ls-files` omits the two artifacts while keeping unrelated and non-excluded files. Two cases: the current layout and a relocated `.planforge/` layout (proving the index-driven derivation).
- Full suite 90/90, tsc + eslint clean. Reviewed by subagent (ship-ready, no must-fix; the one should-fix on index-coupling is addressed here).

## Notes / out of scope
- The committed `planforge-index.json` still references these two paths; it is accurate at generation time (where the files exist). Minor, accepted.
- Direct planforge-CLI users (no project-forge) are not covered; deferred.

Refs: agent-planforge a9311d34, agent-planforge #78 (W2a), project-forge #78 (W1)