### PR TITLE
fix(publish): exclude the whole generation-only planning/ directory, not just plan-output.json

### DIFF
--- a/lib/planforge-output.ts
+++ b/lib/planforge-output.ts
@@ -143,8 +143,12 @@ export async function readScaffoldPreview(tempDir: string): Promise<ScaffoldPrev
 // value once committed into the deliverable. They are kept out of the published
 // repo via .git/info/exclude, which is local to the temp clone and so never
 // collides with scaffoldkit's own committed root .gitignore.
+// The entire planning/ directory is planforge generation/replanning state
+// (plan-output.json + structured-input.json + rerun-report.json +
+// rerun-summary.md). Downstream tools read these at generation time from disk
+// before publish, so none of it belongs in the committed deliverable.
 export const PLANFORGE_PUBLISH_EXCLUDES = [
-  "/planning/plan-output.json",
+  "/planning/",
   "/exports/scaffoldkit-input.json",
 ];
 
@@ -156,9 +160,31 @@ export async function excludePlanforgeArtifactsFromPublish(projectDir: string): 
   const resolved = await resolvePlanforgeOutputPaths(projectDir);
   const toPattern = (absolutePath: string) =>
     `/${path.relative(projectDir, absolutePath).split(path.sep).join("/")}`;
-  const excludes = resolved.hasIndex
-    ? [toPattern(resolved.planOutputPath), toPattern(resolved.scaffoldkitInputPath)]
-    : PLANFORGE_PUBLISH_EXCLUDES;
+  // Exclude the whole planning/ directory (the parent of plan-output.json) so
+  // structured-input.json + rerun-report.json + rerun-summary.md and any future
+  // planning-only artifact are kept out too, not just plan-output.json. Guard
+  // against a flat layout where plan-output.json sits at the repo root: never
+  // turn that into a "/" exclude that would drop the entire deliverable.
+  let excludes: string[];
+  if (resolved.hasIndex) {
+    const planningRel = path
+      .relative(projectDir, path.dirname(resolved.planOutputPath))
+      .split(path.sep)
+      .join("/");
+    const planningDirPattern =
+      planningRel && !planningRel.startsWith("..")
+        ? `/${planningRel}/`
+        : toPattern(resolved.planOutputPath);
+    excludes = [planningDirPattern, toPattern(resolved.scaffoldkitInputPath)];
+  } else {
+    excludes = PLANFORGE_PUBLISH_EXCLUDES;
+  }
+
+  // Never emit a bare "/" (or empty) pattern: a degenerate index value such as
+  // planOutput="." would resolve the planning directory to the repo root. A
+  // bare "/" is a git no-op in practice, but drop it defensively so the exclude
+  // block can never target the whole deliverable.
+  excludes = excludes.filter((pattern) => pattern && pattern !== "/");
 
   const excludePath = path.join(projectDir, ".git", "info", "exclude");
   await fs.mkdir(path.dirname(excludePath), { recursive: true });

--- a/tests/integration/planforge-output.test.ts
+++ b/tests/integration/planforge-output.test.ts
@@ -32,6 +32,8 @@ describe("planforge publish exclusion", () => {
     await fs.writeFile(path.join(tempDir, "planning", "plan-output.json"), "{}\n");
     await fs.writeFile(path.join(tempDir, "exports", "scaffoldkit-input.json"), "{}\n");
     await fs.writeFile(path.join(tempDir, "planning", "structured-input.json"), "{}\n");
+    await fs.writeFile(path.join(tempDir, "planning", "rerun-report.json"), "{}\n");
+    await fs.writeFile(path.join(tempDir, "planning", "rerun-summary.md"), "# rerun\n");
     await fs.writeFile(path.join(tempDir, "README.md"), "# demo\n");
 
     const git = (args: string[]) =>
@@ -50,11 +52,16 @@ describe("planforge publish exclusion", () => {
       .split("\n")
       .filter(Boolean);
 
+    // The whole planning/ directory is generation-only state, not just
+    // plan-output.json: structured-input.json + rerun-report.json +
+    // rerun-summary.md are kept out of the deliverable too.
     expect(staged).not.toContain("planning/plan-output.json");
     expect(staged).not.toContain("exports/scaffoldkit-input.json");
-    // Unrelated and not-yet-excluded files are still committed.
+    expect(staged).not.toContain("planning/structured-input.json");
+    expect(staged).not.toContain("planning/rerun-report.json");
+    expect(staged).not.toContain("planning/rerun-summary.md");
+    // Deliverable files outside planning/ are still committed.
     expect(staged).toContain("README.md");
-    expect(staged).toContain("planning/structured-input.json");
   });
 
   it("derives exclude paths from the index when artifacts are relocated", async () => {
@@ -66,6 +73,7 @@ describe("planforge publish exclusion", () => {
     await fs.mkdir(path.join(tempDir, ".planforge", "planning"), { recursive: true });
     await fs.mkdir(path.join(tempDir, ".planforge", "exports"), { recursive: true });
     await fs.writeFile(path.join(tempDir, ".planforge", "planning", "plan-output.json"), "{}\n");
+    await fs.writeFile(path.join(tempDir, ".planforge", "planning", "structured-input.json"), "{}\n");
     await fs.writeFile(path.join(tempDir, ".planforge", "exports", "scaffoldkit-input.json"), "{}\n");
     await fs.writeFile(path.join(tempDir, "README.md"), "# demo\n");
     await fs.writeFile(
@@ -100,10 +108,70 @@ describe("planforge publish exclusion", () => {
       .split("\n")
       .filter(Boolean);
 
+    // The exclude follows the index-derived planning directory, so every
+    // planning artifact under .planforge/planning/ is kept out, not just
+    // plan-output.json.
     expect(staged).not.toContain(".planforge/planning/plan-output.json");
+    expect(staged).not.toContain(".planforge/planning/structured-input.json");
     expect(staged).not.toContain(".planforge/exports/scaffoldkit-input.json");
     expect(staged).toContain("README.md");
     expect(staged).toContain("planforge-index.json");
+  });
+
+  it("never emits a root exclude for a flat-layout index (root-guard)", async () => {
+    const tempDir = await makeTempDir();
+    tempDirs.push(tempDir);
+
+    // Degenerate flat layout: planning artifacts sit at the repo root, so the
+    // planning directory resolves to the repo root. The guard must fall back to
+    // excluding the single plan-output.json file, never a bare "/" that would
+    // drop the whole deliverable.
+    await fs.writeFile(path.join(tempDir, "plan-output.json"), "{}\n");
+    await fs.writeFile(path.join(tempDir, "scaffoldkit-input.json"), "{}\n");
+    await fs.writeFile(path.join(tempDir, "README.md"), "# demo\n");
+    await fs.writeFile(
+      path.join(tempDir, "planforge-index.json"),
+      JSON.stringify(
+        {
+          generatedBy: "agent-planforge",
+          rootFiles: { agents: "AGENTS.md" },
+          directories: { ai: ".ai", tasks: "tasks" },
+          planning: { planOutput: "plan-output.json" },
+          exports: { scaffoldkit: "scaffoldkit-input.json" },
+          ai: { agents: ".ai/AGENTS.md" },
+        },
+        null,
+        2
+      )
+    );
+
+    const git = (args: string[]) =>
+      execFileSync("git", args, { cwd: tempDir, stdio: "pipe" });
+    git(["init"]);
+    git(["config", "user.email", "t@example.com"]);
+    git(["config", "user.name", "t"]);
+
+    await excludePlanforgeArtifactsFromPublish(tempDir);
+
+    const excludeLines = (
+      await fs.readFile(path.join(tempDir, ".git", "info", "exclude"), "utf-8")
+    )
+      .split("\n")
+      .map((line) => line.trim());
+    expect(excludeLines).not.toContain("/");
+
+    git(["add", "-A"]);
+    const staged = execFileSync("git", ["ls-files"], {
+      cwd: tempDir,
+      encoding: "utf-8",
+    })
+      .split("\n")
+      .filter(Boolean);
+
+    expect(staged).toContain("README.md");
+    expect(staged).toContain("planforge-index.json");
+    expect(staged).not.toContain("plan-output.json");
+    expect(staged).not.toContain("scaffoldkit-input.json");
   });
 });
 


### PR DESCRIPTION
## What

Exclude the whole generation-only planning/ directory from the published repo, not just plan-output.json.

## Why

Found by the r2 re-dogfood (github.com/LanNguyenSi/dogfood-quicklinks-r2). #79 excluded plan-output.json and scaffoldkit-input.json, but structured-input.json, rerun-report.json and rerun-summary.md are the same generation and replanning state and were still committed into the deliverable.

## Changes

- lib/planforge-output.ts: exclude the whole planning/ directory via .git/info/exclude, derived from the index (dirname of plan-output) so it tracks layout moves, with a root-guard that falls back to the single file and never emits a bare "/" for a degenerate index.
- tests/integration/planforge-output.test.ts: assert the whole planning/ directory is excluded in both the no-index fallback and index-derived cases, with README.md and planforge-index.json as negative controls, plus a flat-layout root-guard case.

## Test plan

- tsc --noEmit, eslint, vitest (8/8) green.
- Reviewed by a review subagent (verdict: ship, no must-fix).

Refs: agent-tasks d3bfb831