### PR TITLE
feat(publish): surface the wave-0 blueprint-fit gate at the front of the agent entry path

### DIFF
--- a/lib/post-scaffold-review.ts
+++ b/lib/post-scaffold-review.ts
@@ -465,6 +465,92 @@ Confirm that the selected scaffold baseline is appropriate for this project befo
   return { path: filePath, contents };
 }
 
+const BLUEPRINT_GATE_TASK_ID = "900";
+const BLUEPRINT_GATE_TASK_FILE = "tasks/900-blueprint-fit-review.md";
+
+const AI_TASKS_WAVE0_BLOCK = `## wave-0
+
+Resolve the blueprint-fit review before any wave-1 work.
+
+### ${BLUEPRINT_GATE_TASK_ID} Review scaffold blueprint fit against the plan
+
+- Priority: P0
+- Category: foundation
+- Depends on: none
+- Summary: The selected scaffold blueprint may not match the plan; resolve \`${BLUEPRINT_GATE_TASK_FILE}\` before starting wave-1 implementation.
+
+`;
+
+const AGENTS_GATE_CALLOUT = `> Blocked: resolve the wave-0 blueprint-fit review in \`${BLUEPRINT_GATE_TASK_FILE}\` before any wave-1 work. The selected scaffold blueprint may not match the plan.`;
+
+// planforge writes .ai/TASKS.md and the root AGENTS.md before project-forge runs
+// the scaffold-fit review, so when this review emits the wave-0 blueprint-fit
+// gate (tasks/900) neither entry doc references it: an agent following the
+// entry path starts wave-1, which the gate forbids. Surface the gate at the
+// front of both. Best-effort and idempotent: if the expected structure is
+// absent, leave the file untouched rather than risk corrupting generated output.
+// The regex anchors below mirror agent-planforge's generator output
+// (scripts/bootstrap-plan.js: renderAiTasks for .ai/TASKS.md, the root AGENTS.md
+// renderer for "## Build This Next"); if that format drifts, these patches
+// no-op instead of mangling the file.
+async function surfaceBlueprintGateInEntryArtifacts(tempDir: string): Promise<void> {
+  await surfaceGateInAiTasks(path.join(tempDir, ".ai", "TASKS.md"));
+  await surfaceGateInRootAgents(path.join(tempDir, "AGENTS.md"));
+}
+
+async function surfaceGateInAiTasks(filePath: string): Promise<void> {
+  let body: string;
+  try {
+    body = await fs.readFile(filePath, "utf-8");
+  } catch {
+    return;
+  }
+
+  let next = body;
+
+  // Prepend the gate to the Critical Path line (idempotent).
+  next = next.replace(
+    /(## Critical Path\n\n)([^\n]*)/,
+    (match, heading: string, criticalPath: string) =>
+      criticalPath.startsWith(`${BLUEPRINT_GATE_TASK_ID} -> `)
+        ? match
+        : `${heading}${BLUEPRINT_GATE_TASK_ID} -> ${criticalPath}`
+  );
+
+  // Insert a wave-0 section before the first wave section (idempotent).
+  if (!next.includes("## wave-0") && /\n## wave-/.test(next)) {
+    next = next.replace(/\n## wave-/, `\n${AI_TASKS_WAVE0_BLOCK}## wave-`);
+  }
+
+  if (next !== body) {
+    await fs.writeFile(filePath, next);
+  }
+}
+
+async function surfaceGateInRootAgents(filePath: string): Promise<void> {
+  let body: string;
+  try {
+    body = await fs.readFile(filePath, "utf-8");
+  } catch {
+    return;
+  }
+
+  // The gate file path only appears here once surfaced, so it doubles as the
+  // idempotency marker.
+  if (body.includes(BLUEPRINT_GATE_TASK_FILE)) {
+    return;
+  }
+
+  const next = body.replace(
+    /(## Build This Next\n\n)/,
+    `$1${AGENTS_GATE_CALLOUT}\n\n`
+  );
+
+  if (next !== body) {
+    await fs.writeFile(filePath, next);
+  }
+}
+
 // post-scaffold-review is project-forge's own assessment artifact, not part of
 // the planforge handoff bundle. It is written under .planforge/ (a planner-side
 // namespace) so it no longer depends on the handoff/ directory, which
@@ -557,6 +643,7 @@ export async function runPostScaffoldReview(tempDir: string): Promise<PostScaffo
       `${JSON.stringify(review, null, 2)}\n`
     );
     await fs.writeFile(path.join(reviewDir, "post-scaffold-review.md"), renderReviewMarkdown(review));
+    await surfaceBlueprintGateInEntryArtifacts(tempDir);
   }
 
   return review;
@@ -588,4 +675,5 @@ export const __internal = {
   buildDeterministicChecks,
   summarizeDeterministicVerdict,
   toScaffoldFitPreview,
+  surfaceBlueprintGateInEntryArtifacts,
 };

--- a/tests/integration/post-scaffold-review.test.ts
+++ b/tests/integration/post-scaffold-review.test.ts
@@ -137,3 +137,158 @@ describe("post-scaffold review artifact relocation", () => {
     expect(readBack?.blueprint.selected).toBe("rest-api");
   });
 });
+
+describe("post-scaffold review surfaces the blueprint-fit gate in the entry path", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  const AI_TASKS_FIXTURE = `# TASKS
+
+## Critical Path
+
+001 -> 002 -> 003
+
+## wave-1
+
+Lock scope, assumptions, and engineering baseline.
+
+### 001 Write project charter and architecture baseline
+
+- Priority: P0
+- Category: foundation
+- Depends on: none
+- Summary: Capture scope.
+`;
+
+  const AGENTS_FIXTURE = `# AGENTS
+
+## Build This Next
+
+1. Read \`.planforge/docs/architecture-overview.md\` for the intended architecture.
+2. Work the generated tasks in \`tasks/\` in dependency order (see \`.ai/TASKS.md\`).
+3. Keep \`PROJECT.md\` and \`.ai/\` as the standing context.
+
+## Important Files
+
+- Machine-readable index: \`planforge-index.json\`
+`;
+
+  async function makeEntryRepo(): Promise<string> {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "project-forge-gate-"));
+    tempDirs.push(tempDir);
+    await fs.mkdir(path.join(tempDir, ".ai"), { recursive: true });
+    await fs.mkdir(path.join(tempDir, "tasks"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, ".ai", "TASKS.md"), AI_TASKS_FIXTURE);
+    await fs.writeFile(path.join(tempDir, "AGENTS.md"), AGENTS_FIXTURE);
+    return tempDir;
+  }
+
+  it("prepends the gate to .ai/TASKS.md and AGENTS.md when surfaced", async () => {
+    const tempDir = await makeEntryRepo();
+    await __internal.surfaceBlueprintGateInEntryArtifacts(tempDir);
+
+    const tasks = await fs.readFile(path.join(tempDir, ".ai", "TASKS.md"), "utf-8");
+    expect(tasks).toContain("## Critical Path\n\n900 -> 001 -> 002 -> 003");
+    expect(tasks).toContain("### 900 Review scaffold blueprint fit against the plan");
+    // wave-0 sits before wave-1.
+    expect(tasks.indexOf("## wave-0")).toBeGreaterThanOrEqual(0);
+    expect(tasks.indexOf("## wave-0")).toBeLessThan(tasks.indexOf("## wave-1"));
+
+    const agents = await fs.readFile(path.join(tempDir, "AGENTS.md"), "utf-8");
+    expect(agents).toContain("tasks/900-blueprint-fit-review.md");
+    // The gate callout sits under the Build This Next heading, before step 1.
+    expect(agents.indexOf("Blocked: resolve")).toBeGreaterThanOrEqual(0);
+    expect(agents.indexOf("Blocked: resolve")).toBeLessThan(agents.indexOf("1. Read"));
+  });
+
+  it("is idempotent (no double insert)", async () => {
+    const tempDir = await makeEntryRepo();
+    await __internal.surfaceBlueprintGateInEntryArtifacts(tempDir);
+    const tasksOnce = await fs.readFile(path.join(tempDir, ".ai", "TASKS.md"), "utf-8");
+    const agentsOnce = await fs.readFile(path.join(tempDir, "AGENTS.md"), "utf-8");
+
+    await __internal.surfaceBlueprintGateInEntryArtifacts(tempDir);
+    const tasksTwice = await fs.readFile(path.join(tempDir, ".ai", "TASKS.md"), "utf-8");
+    const agentsTwice = await fs.readFile(path.join(tempDir, "AGENTS.md"), "utf-8");
+
+    expect(tasksTwice).toBe(tasksOnce);
+    expect(agentsTwice).toBe(agentsOnce);
+    expect((tasksTwice.match(/## wave-0/g) || []).length).toBe(1);
+    expect((agentsTwice.match(/Blocked: resolve/g) || []).length).toBe(1);
+  });
+
+  it("no-ops without throwing when the entry docs are absent", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "project-forge-gate-empty-"));
+    tempDirs.push(tempDir);
+    await expect(
+      __internal.surfaceBlueprintGateInEntryArtifacts(tempDir)
+    ).resolves.toBeUndefined();
+  });
+
+  it("runPostScaffoldReview surfaces the gate on a mismatch (weak confidence)", async () => {
+    const tempDir = await makeEntryRepo();
+    await fs.writeFile(
+      path.join(tempDir, "scaffoldkit-input.json"),
+      JSON.stringify(
+        {
+          projectName: "demo",
+          blueprint: "rest-api",
+          blueprintConfidence: "weak",
+          agentMustCreateStructure: true,
+        },
+        null,
+        2
+      )
+    );
+
+    const review = await runPostScaffoldReview(tempDir);
+    expect(review.verdict.mustReviewBeforeImplementation).toBe(true);
+
+    const tasks = await fs.readFile(path.join(tempDir, ".ai", "TASKS.md"), "utf-8");
+    const agents = await fs.readFile(path.join(tempDir, "AGENTS.md"), "utf-8");
+    expect(tasks).toContain("900 -> 001 -> 002 -> 003");
+    expect(tasks).toContain("## wave-0");
+    expect(agents).toContain("tasks/900-blueprint-fit-review.md");
+  });
+
+  it("runPostScaffoldReview leaves the entry docs untouched on an ok verdict", async () => {
+    const tempDir = await makeEntryRepo();
+    const tasksBefore = await fs.readFile(path.join(tempDir, ".ai", "TASKS.md"), "utf-8");
+    const agentsBefore = await fs.readFile(path.join(tempDir, "AGENTS.md"), "utf-8");
+
+    // Strong blueprint + a runtime signal file => all checks pass => ok => no gate.
+    await fs.writeFile(path.join(tempDir, "pyproject.toml"), '[project]\nname = "demo"\n');
+    await fs.writeFile(
+      path.join(tempDir, "scaffoldkit-input.json"),
+      JSON.stringify(
+        {
+          projectName: "demo",
+          blueprint: "rest-api",
+          blueprintConfidence: "strong",
+          agentMustCreateStructure: false,
+        },
+        null,
+        2
+      )
+    );
+
+    const review = await runPostScaffoldReview(tempDir);
+    expect(review.verdict.status).toBe("ok");
+
+    expect(await fs.readFile(path.join(tempDir, ".ai", "TASKS.md"), "utf-8")).toBe(
+      tasksBefore
+    );
+    expect(await fs.readFile(path.join(tempDir, "AGENTS.md"), "utf-8")).toBe(
+      agentsBefore
+    );
+    await expect(
+      fs.access(path.join(tempDir, "tasks", "900-blueprint-fit-review.md"))
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## What

On a blueprint mismatch, surface the wave-0 blueprint-fit gate (tasks/900) at the front of the agent entry path, so an agent starts by resolving the gate instead of jumping into wave-1.

## Why

Found by the r3 fresh-implementer dogfood (github.com/LanNguyenSi/dogfood-quicklinks-r3). post-scaffold-review writes a P0 wave-0 stop-gate ("do not begin wave-1 until resolved"), but the entry docs planforge wrote earlier (.ai/TASKS.md Critical Path 001 to 008, root AGENTS.md "Build This Next") never reference it, so a compliant agent started wave-1 anyway.

## Changes

- lib/post-scaffold-review.ts: when the gate is emitted (verdict not ok), surfaceBlueprintGateInEntryArtifacts patches .ai/TASKS.md (prepend "900 -> " to the Critical Path plus a wave-0 section before wave-1) and root AGENTS.md (a callout under "Build This Next"). Best-effort and idempotent: no-op if the expected structure is absent, never corrupts or throws.
- tests/integration/post-scaffold-review.test.ts: surfacing, idempotency, missing-anchor no-op, wired mismatch path, ok-verdict negative control.

## Test plan

- tsc --noEmit, eslint, vitest (full suite 96 incl. 5 new) green.
- Reviewed by a two-lens subagent workflow (correctness plus regex/corruption), verdict ship, no must-fix; in-scope polish applied inline.

Refs: agent-tasks c5ad0af2