### PR TITLE
fix(review): require a real source file for runtime-structure-present

### DIFF
--- a/lib/post-scaffold-review.ts
+++ b/lib/post-scaffold-review.ts
@@ -127,20 +127,18 @@ const PLANFORGE_TOP_LEVEL_PATHS = new Set([
   "project-input.json",
 ]);
 
-const RUNTIME_SIGNAL_FILES = [
-  "package.json",
-  "requirements.txt",
-  "pyproject.toml",
-  "Cargo.toml",
-  "go.mod",
-  "composer.json",
-  "Gemfile",
-  "pom.xml",
-  "build.gradle",
-  "Dockerfile",
-  "src",
-  "app",
-];
+// "Runtime structure present" means actual source code was generated, not just
+// a manifest (pyproject.toml / package.json) or a bare src/ directory. An empty
+// scaffold (e.g. a non-TypeScript selection of a TS-only blueprint) leaves a
+// manifest plus empty dirs; treating those as runtime structure is exactly the
+// "full scaffold" overclaim this check exists to catch, so require a real
+// source file instead.
+const SOURCE_FILE_EXTENSIONS = new Set([
+  ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
+  ".py", ".go", ".rs", ".rb", ".php", ".java", ".kt",
+  ".cs", ".swift", ".c", ".cc", ".cpp", ".h", ".hpp",
+  ".scala", ".ex", ".exs", ".clj", ".sql",
+]);
 
 const REVIEW_SYSTEM_PROMPT = `You review whether a scaffold blueprint is a good fit for a project after scaffolding.
 
@@ -213,12 +211,12 @@ async function collectRuntimePaths(rootDir: string, maxPaths = 60): Promise<{ to
 }
 
 function hasRuntimeSignals(runtimeIndicators: { topLevelPaths: string[]; samplePaths: string[] }): boolean {
-  const candidates = new Set<string>([
-    ...runtimeIndicators.topLevelPaths,
-    ...runtimeIndicators.samplePaths.map((filePath) => filePath.split(path.sep)[0] || filePath),
-  ]);
-
-  return RUNTIME_SIGNAL_FILES.some((signal) => candidates.has(signal));
+  // A generated source file (top-level or in any sampled directory, at any
+  // depth) is the honest signal that runtime structure exists. A bare src/ dir
+  // or a lone manifest does not count.
+  return [...runtimeIndicators.topLevelPaths, ...runtimeIndicators.samplePaths].some(
+    (filePath) => SOURCE_FILE_EXTENSIONS.has(path.extname(filePath).toLowerCase())
+  );
 }
 
 function buildDeterministicChecks(

--- a/tests/integration/post-scaffold-review.test.ts
+++ b/tests/integration/post-scaffold-review.test.ts
@@ -42,6 +42,35 @@ describe("post-scaffold review helpers", () => {
     expect(verdict.mustReviewBeforeImplementation).toBe(true);
   });
 
+  it("treats a manifest plus an empty src/ as NOT runtime-present (honest verdict)", () => {
+    // The r4 over-claim: pyproject.toml is generated but src/ is an empty dir
+    // with no source files, so collectRuntimePaths samples only the manifest.
+    const checks = __internal.buildDeterministicChecks(
+      { blueprint: "rest-api", blueprintConfidence: "strong", agentMustCreateStructure: false },
+      { topLevelPaths: ["pyproject.toml", "src"], samplePaths: ["pyproject.toml"] }
+    );
+
+    const runtime = checks.find((check) => check.id === "runtime-structure-present");
+    expect(runtime?.status).toBe("warn");
+
+    const verdict = __internal.summarizeDeterministicVerdict(checks);
+    expect(verdict.status).not.toBe("ok");
+    expect(verdict.mustReviewBeforeImplementation).toBe(true);
+  });
+
+  it("treats a generated source file as runtime-present", () => {
+    const checks = __internal.buildDeterministicChecks(
+      { blueprint: "rest-api", blueprintConfidence: "strong", agentMustCreateStructure: false },
+      { topLevelPaths: ["src"], samplePaths: ["src/index.ts"] }
+    );
+
+    const runtime = checks.find((check) => check.id === "runtime-structure-present");
+    expect(runtime?.status).toBe("pass");
+
+    const verdict = __internal.summarizeDeterministicVerdict(checks);
+    expect(verdict.status).toBe("ok");
+  });
+
   it("maps implementation gate into scaffold fit preview", () => {
     const preview = __internal.toScaffoldFitPreview({
       version: "1.0",
@@ -135,6 +164,36 @@ describe("post-scaffold review artifact relocation", () => {
     expect(readBack).not.toBeNull();
     expect(readBack?.verdict.status).toBe(written.verdict.status);
     expect(readBack?.blueprint.selected).toBe("rest-api");
+  });
+
+  it("warns on a manifest plus an empty src/ via the real on-disk sampler (no source code)", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "project-forge-empty-scaffold-"));
+    tempDirs.push(tempDir);
+
+    await fs.mkdir(path.join(tempDir, "tasks"), { recursive: true });
+    await fs.mkdir(path.join(tempDir, "src"), { recursive: true }); // empty dir, no code
+    await fs.writeFile(path.join(tempDir, "pyproject.toml"), '[project]\nname = "demo"\n');
+    await fs.writeFile(
+      path.join(tempDir, "scaffoldkit-input.json"),
+      JSON.stringify(
+        {
+          projectName: "demo",
+          blueprint: "rest-api",
+          blueprintConfidence: "strong",
+          agentMustCreateStructure: false,
+        },
+        null,
+        2
+      )
+    );
+
+    const review = await runPostScaffoldReview(tempDir);
+
+    // Even with a strong blueprint, an empty scaffold (manifest + empty src/,
+    // no source file) must not be green-lit as runtime-present.
+    const runtime = review.checks.find((check) => check.id === "runtime-structure-present");
+    expect(runtime?.status).toBe("warn");
+    expect(review.verdict.status).not.toBe("ok");
   });
 });
 
@@ -262,8 +321,10 @@ Lock scope, assumptions, and engineering baseline.
     const tasksBefore = await fs.readFile(path.join(tempDir, ".ai", "TASKS.md"), "utf-8");
     const agentsBefore = await fs.readFile(path.join(tempDir, "AGENTS.md"), "utf-8");
 
-    // Strong blueprint + a runtime signal file => all checks pass => ok => no gate.
+    // Strong blueprint + real source code => all checks pass => ok => no gate.
     await fs.writeFile(path.join(tempDir, "pyproject.toml"), '[project]\nname = "demo"\n');
+    await fs.mkdir(path.join(tempDir, "src"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, "src", "main.py"), "def main():\n    return 0\n");
     await fs.writeFile(
       path.join(tempDir, "scaffoldkit-input.json"),
       JSON.stringify(


### PR DESCRIPTION
## What

Make the runtime-structure-present review check honest: it no longer treats an empty scaffold as usable.

## Why

Found by the r4 dogfood plus a root-cause map. A bare src/ dir or a lone manifest (pyproject.toml/package.json) passed the check, so an empty cli-tool husk (no source files) was reported as a "full" runtime structure.

## Changes

- lib/post-scaffold-review.ts: hasRuntimeSignals now requires at least one actual source file (by extension) among the top-level and sampled paths, instead of bare set-membership of "src"/"app"/manifest names (RUNTIME_SIGNAL_FILES removed). collectRuntimePaths already recurses and excludes planforge artifacts, so this reflects the real scaffold output. An empty scaffold honestly reports runtime-structure: warn.
- tests: empty manifest plus empty src/ warns (unit and end-to-end via the real on-disk sampler); a real source file passes; the prior ok-verdict test now includes real code.

## Test plan

- tsc --noEmit, eslint, full vitest (99) green.
- Reviewed by a subagent workflow (ship, no must-fix).

Refs: agent-tasks 3ed4f6bb