### PR TITLE
fix(preview): gate the "Full scaffold" label on real source, not confidence alone

### DIFF
--- a/lib/planforge-output.ts
+++ b/lib/planforge-output.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs/promises";
 import * as path from "path";
+import { collectRuntimePaths, hasRuntimeSignals } from "@/lib/runtime-signals";
 import type { ScaffoldPreview } from "@/lib/types";
 
 type PathMap = Record<string, string>;
@@ -128,6 +129,15 @@ export async function readScaffoldPreview(tempDir: string): Promise<ScaffoldPrev
     };
 
     if (parsed.agentMustCreateStructure || parsed.blueprintConfidence === "weak") {
+      return PLANNING_BASELINE;
+    }
+
+    // A strong blueprint selection is not enough: if the scaffold emitted no real
+    // source (only a manifest plus empty dirs), it is a planning baseline, not a
+    // "full scaffold". Reuse the exact source-file signal #82 added to the
+    // post-scaffold review verdict so the preview label and the verdict agree.
+    const runtimeIndicators = await collectRuntimePaths(tempDir);
+    if (!hasRuntimeSignals(runtimeIndicators)) {
       return PLANNING_BASELINE;
     }
 

--- a/lib/post-scaffold-review.ts
+++ b/lib/post-scaffold-review.ts
@@ -2,6 +2,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { getAiCapabilities, generateStructuredJson, type AiProviderName } from "@/lib/ai-provider";
 import { resolvePlanforgeOutputPaths } from "@/lib/planforge-output";
+import { collectRuntimePaths, hasRuntimeSignals } from "@/lib/runtime-signals";
 import type { ScaffoldFitPreview } from "@/lib/types";
 
 type CheckStatus = "pass" | "warn" | "fail";
@@ -91,55 +92,6 @@ interface ReviewPayload {
   };
 }
 
-// Planforge artifacts that should NOT be counted as runtime scaffold signals.
-// Since the output reorganization (bf7a491), most JSON files moved into
-// planning/, handoff/, and exports/ subdirectories, and the planning prose
-// docs now live under .planforge/docs/. The directory entries below cover
-// the subdirs (including the .planforge/ namespace) and the root-level
-// markdown/index files. The bare root-level doc names are retained so older
-// flat-root tarballs still match.
-const PLANFORGE_TOP_LEVEL_PATHS = new Set([
-  // Directories
-  ".ai",
-  ".planforge",
-  "adrs",
-  "exports",
-  "governance",
-  // Back-compat: agent-planforge stops emitting handoff/ once the runner vision
-  // is removed (Phase 3). Retained so older flat tarballs still match; safe to
-  // drop after the migration window.
-  "handoff",
-  "planning",
-  "prompts",
-  "runbooks",
-  "specs",
-  "tasks",
-  // Root-level files
-  "AGENTS.md",
-  "BRANCH_INFO.md",
-  "CLAUDE.md",
-  "PROJECT.md",
-  "architecture-overview.md",
-  "delivery-plan.md",
-  "intake-questionnaire.md",
-  "planforge-index.json",
-  "project-charter.md",
-  "project-input.json",
-]);
-
-// "Runtime structure present" means actual source code was generated, not just
-// a manifest (pyproject.toml / package.json) or a bare src/ directory. An empty
-// scaffold (e.g. a non-TypeScript selection of a TS-only blueprint) leaves a
-// manifest plus empty dirs; treating those as runtime structure is exactly the
-// "full scaffold" overclaim this check exists to catch, so require a real
-// source file instead.
-const SOURCE_FILE_EXTENSIONS = new Set([
-  ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
-  ".py", ".go", ".rs", ".rb", ".php", ".java", ".kt",
-  ".cs", ".swift", ".c", ".cc", ".cpp", ".h", ".hpp",
-  ".scala", ".ex", ".exs", ".clj", ".sql",
-]);
-
 const REVIEW_SYSTEM_PROMPT = `You review whether a scaffold blueprint is a good fit for a project after scaffolding.
 
 Return ONLY a JSON object with:
@@ -161,62 +113,6 @@ async function readJsonFile<T>(filePath: string): Promise<T | null> {
   } catch {
     return null;
   }
-}
-
-async function collectRuntimePaths(rootDir: string, maxPaths = 60): Promise<{ topLevelPaths: string[]; samplePaths: string[] }> {
-  const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch(() => []);
-  const topLevelPaths = entries
-    .map((entry) => entry.name)
-    .filter((name) => !PLANFORGE_TOP_LEVEL_PATHS.has(name) && name !== ".git" && name !== "node_modules")
-    .sort();
-
-  const samplePaths: string[] = [];
-
-  async function visit(relativeDir: string) {
-    if (samplePaths.length >= maxPaths) {
-      return;
-    }
-
-    const fullDir = path.join(rootDir, relativeDir);
-    const children = await fs.readdir(fullDir, { withFileTypes: true }).catch(() => []);
-
-    for (const child of children) {
-      if (samplePaths.length >= maxPaths) {
-        return;
-      }
-
-      const childRelative = relativeDir ? path.join(relativeDir, child.name) : child.name;
-      if (child.name === ".git" || child.name === "node_modules") {
-        continue;
-      }
-
-      samplePaths.push(childRelative);
-      if (child.isDirectory()) {
-        await visit(childRelative);
-      }
-    }
-  }
-
-  for (const topLevelPath of topLevelPaths) {
-    if (samplePaths.length >= maxPaths) {
-      break;
-    }
-    await visit(topLevelPath);
-  }
-
-  return {
-    topLevelPaths,
-    samplePaths,
-  };
-}
-
-function hasRuntimeSignals(runtimeIndicators: { topLevelPaths: string[]; samplePaths: string[] }): boolean {
-  // A generated source file (top-level or in any sampled directory, at any
-  // depth) is the honest signal that runtime structure exists. A bare src/ dir
-  // or a lone manifest does not count.
-  return [...runtimeIndicators.topLevelPaths, ...runtimeIndicators.samplePaths].some(
-    (filePath) => SOURCE_FILE_EXTENSIONS.has(path.extname(filePath).toLowerCase())
-  );
 }
 
 function buildDeterministicChecks(

--- a/lib/runtime-signals.ts
+++ b/lib/runtime-signals.ts
@@ -1,0 +1,114 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+
+// Shared runtime-structure detection: did the scaffold emit real source code, or
+// only a manifest plus empty directories? Both the post-scaffold review (the
+// verdict) and the scaffold preview (the "Full scaffold" vs "Planning baseline"
+// label) must agree on this signal, so it lives here as a single source of truth
+// instead of being duplicated across lib/post-scaffold-review.ts and
+// lib/planforge-output.ts.
+
+// Planforge artifacts that should NOT be counted as runtime scaffold signals.
+// Since the output reorganization (bf7a491), most JSON files moved into
+// planning/, handoff/, and exports/ subdirectories, and the planning prose
+// docs now live under .planforge/docs/. The directory entries below cover
+// the subdirs (including the .planforge/ namespace) and the root-level
+// markdown/index files. The bare root-level doc names are retained so older
+// flat-root tarballs still match.
+export const PLANFORGE_TOP_LEVEL_PATHS = new Set([
+  // Directories
+  ".ai",
+  ".planforge",
+  "adrs",
+  "exports",
+  "governance",
+  // Back-compat: agent-planforge stops emitting handoff/ once the runner vision
+  // is removed (Phase 3). Retained so older flat tarballs still match; safe to
+  // drop after the migration window.
+  "handoff",
+  "planning",
+  "prompts",
+  "runbooks",
+  "specs",
+  "tasks",
+  // Root-level files
+  "AGENTS.md",
+  "BRANCH_INFO.md",
+  "CLAUDE.md",
+  "PROJECT.md",
+  "architecture-overview.md",
+  "delivery-plan.md",
+  "intake-questionnaire.md",
+  "planforge-index.json",
+  "project-charter.md",
+  "project-input.json",
+]);
+
+// "Runtime structure present" means actual source code was generated, not just
+// a manifest (pyproject.toml / package.json) or a bare src/ directory. An empty
+// scaffold (e.g. a non-TypeScript selection of a TS-only blueprint) leaves a
+// manifest plus empty dirs; treating those as runtime structure is exactly the
+// "full scaffold" overclaim this check exists to catch, so require a real
+// source file instead.
+const SOURCE_FILE_EXTENSIONS = new Set([
+  ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
+  ".py", ".go", ".rs", ".rb", ".php", ".java", ".kt",
+  ".cs", ".swift", ".c", ".cc", ".cpp", ".h", ".hpp",
+  ".scala", ".ex", ".exs", ".clj", ".sql",
+]);
+
+export async function collectRuntimePaths(rootDir: string, maxPaths = 60): Promise<{ topLevelPaths: string[]; samplePaths: string[] }> {
+  const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch(() => []);
+  const topLevelPaths = entries
+    .map((entry) => entry.name)
+    .filter((name) => !PLANFORGE_TOP_LEVEL_PATHS.has(name) && name !== ".git" && name !== "node_modules")
+    .sort();
+
+  const samplePaths: string[] = [];
+
+  async function visit(relativeDir: string) {
+    if (samplePaths.length >= maxPaths) {
+      return;
+    }
+
+    const fullDir = path.join(rootDir, relativeDir);
+    const children = await fs.readdir(fullDir, { withFileTypes: true }).catch(() => []);
+
+    for (const child of children) {
+      if (samplePaths.length >= maxPaths) {
+        return;
+      }
+
+      const childRelative = relativeDir ? path.join(relativeDir, child.name) : child.name;
+      if (child.name === ".git" || child.name === "node_modules") {
+        continue;
+      }
+
+      samplePaths.push(childRelative);
+      if (child.isDirectory()) {
+        await visit(childRelative);
+      }
+    }
+  }
+
+  for (const topLevelPath of topLevelPaths) {
+    if (samplePaths.length >= maxPaths) {
+      break;
+    }
+    await visit(topLevelPath);
+  }
+
+  return {
+    topLevelPaths,
+    samplePaths,
+  };
+}
+
+export function hasRuntimeSignals(runtimeIndicators: { topLevelPaths: string[]; samplePaths: string[] }): boolean {
+  // A generated source file (top-level or in any sampled directory, at any
+  // depth) is the honest signal that runtime structure exists. A bare src/ dir
+  // or a lone manifest does not count.
+  return [...runtimeIndicators.topLevelPaths, ...runtimeIndicators.samplePaths].some(
+    (filePath) => SOURCE_FILE_EXTENSIONS.has(path.extname(filePath).toLowerCase())
+  );
+}

--- a/tests/integration/planforge-output.test.ts
+++ b/tests/integration/planforge-output.test.ts
@@ -355,6 +355,56 @@ describe("planforge output resolver", () => {
     expect(preview.status).toBe("planning-baseline");
   });
 
+  it("labels a strong-confidence scaffold that emitted no source as planning baseline, not full", async () => {
+    const tempDir = await makeTempDir();
+    tempDirs.push(tempDir);
+
+    // Strong confidence and the agent need not create structure, but the scaffold
+    // wrote no real source file (only the planforge input manifest). The label
+    // must not overclaim "full scaffold".
+    await fs.writeFile(
+      path.join(tempDir, "scaffoldkit-input.json"),
+      JSON.stringify({ blueprintConfidence: "strong", agentMustCreateStructure: false }, null, 2)
+    );
+
+    const preview = await readScaffoldPreview(tempDir);
+
+    expect(preview.status).toBe("planning-baseline");
+    expect(preview.label).not.toBe("Full scaffold");
+  });
+
+  it("labels a strong-confidence scaffold with real source as full", async () => {
+    const tempDir = await makeTempDir();
+    tempDirs.push(tempDir);
+
+    await fs.writeFile(
+      path.join(tempDir, "scaffoldkit-input.json"),
+      JSON.stringify({ blueprintConfidence: "strong", agentMustCreateStructure: false }, null, 2)
+    );
+    await fs.mkdir(path.join(tempDir, "src"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, "src", "index.ts"), "export const x = 1;\n");
+
+    const preview = await readScaffoldPreview(tempDir);
+
+    expect(preview.status).toBe("full");
+  });
+
+  it("keeps weak confidence as planning baseline even when source is present (confidence gate wins)", async () => {
+    const tempDir = await makeTempDir();
+    tempDirs.push(tempDir);
+
+    await fs.writeFile(
+      path.join(tempDir, "scaffoldkit-input.json"),
+      JSON.stringify({ blueprintConfidence: "weak" }, null, 2)
+    );
+    await fs.mkdir(path.join(tempDir, "src"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, "src", "index.ts"), "export const x = 1;\n");
+
+    const preview = await readScaffoldPreview(tempDir);
+
+    expect(preview.status).toBe("planning-baseline");
+  });
+
   it("treats an index without a handoff block as valid (post-Phase-3 layout)", async () => {
     const tempDir = await makeTempDir();
     tempDirs.push(tempDir);


### PR DESCRIPTION
## Problem

`readScaffoldPreview` derived the "Full scaffold" label from `blueprintConfidence` / `agentMustCreateStructure` alone, so a strong blueprint selection was labelled "Full scaffold" even when the scaffold emitted no source code (only a manifest plus empty dirs). PR #82 already made the post-scaffold-review verdict honest with a source-file signal; the preview label was never updated to match.

## Change

- `readScaffoldPreview` now also gates `FULL_SCAFFOLD` on real runtime structure (a generated source file, by extension), reusing the exact signal #82 added. A scaffold is "full" only if it is both confidently matched and has real source.
- To avoid a circular import (`post-scaffold-review.ts` already imports from `planforge-output.ts`), the shared detection (`PLANFORGE_TOP_LEVEL_PATHS`, `SOURCE_FILE_EXTENSIONS`, `collectRuntimePaths`, `hasRuntimeSignals`) moves to a new `lib/runtime-signals.ts` that both modules import. The label and the verdict now share one source of truth.

## Tests

3 new cases in `planforge-output.test.ts`: strong-confidence + no source becomes planning-baseline (the regression, previously "full"), strong-confidence + real source becomes full, weak-confidence + source present stays planning-baseline (confidence gate wins, proving AND not OR).

## Verification

`tsc --noEmit` clean, `eslint` clean, full `vitest` 102 passed. Review subagent: SHIP, no issues (circular import confirmed broken, extraction byte-for-byte behavior-preserving).

Refs: agent-tasks 42b0fbe6