### PR TITLE
fix(publish): prune the shipped planforge index of excluded paths

### DIFF
--- a/app/api/publish/route.ts
+++ b/app/api/publish/route.ts
@@ -4,7 +4,7 @@ import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import * as fs from "fs/promises";
 import * as path from "path";
-import { excludePlanforgeArtifactsFromPublish } from "@/lib/planforge-output";
+import { excludePlanforgeArtifactsFromPublish, prunePublishedPlanforgeIndex } from "@/lib/planforge-output";
 import type { PublishResponse, ErrorResponse } from "../../../lib/types";
 import { runCommand } from "@/lib/subprocess";
 import { SESSION_UUID_RE, readForgeMeta, isSessionExpired } from "@/lib/v1-shared";
@@ -193,6 +193,7 @@ async function runGitCommands(
 
   await git(["init", "-b", "main"]);
   await excludePlanforgeArtifactsFromPublish(repoPath);
+  await prunePublishedPlanforgeIndex(repoPath);
   await git(["config", "user.email", "forge@project-forge.dev"]);
   await git(["config", "user.name", "project-forge"]);
   await git(["add", "-A"]);

--- a/app/api/v1/projects/route.ts
+++ b/app/api/v1/projects/route.ts
@@ -3,7 +3,7 @@ import { validateApiToken, checkRateLimit, prisma } from "@/lib/db";
 import { randomUUID } from "crypto";
 import * as fs from "fs/promises";
 import * as path from "path";
-import { excludePlanforgeArtifactsFromPublish } from "@/lib/planforge-output";
+import { excludePlanforgeArtifactsFromPublish, prunePublishedPlanforgeIndex } from "@/lib/planforge-output";
 import { buildPlanforgeInput } from "@/lib/planforge-orchestrator";
 import { runPlanforgeViaHttp, PlanforgeClientError, assertScaffoldkitRan } from "@/lib/planforge-client";
 import { runPostScaffoldReview } from "@/lib/post-scaffold-review";
@@ -291,6 +291,7 @@ async function createAndPushRepo(
 
   await git(["init"]);
   await excludePlanforgeArtifactsFromPublish(projectDir);
+  await prunePublishedPlanforgeIndex(projectDir);
   await git(["config", "user.email", "forge@project-forge.dev"]);
   await git(["config", "user.name", "project-forge"]);
   await git(["add", "."]);

--- a/app/api/v1/publish/route.ts
+++ b/app/api/v1/publish/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { validateApiToken, checkRateLimit, prisma } from "@/lib/db";
 import * as fs from "fs/promises";
 import * as path from "path";
-import { excludePlanforgeArtifactsFromPublish } from "@/lib/planforge-output";
+import { excludePlanforgeArtifactsFromPublish, prunePublishedPlanforgeIndex } from "@/lib/planforge-output";
 import type { ErrorResponse } from "@/lib/types";
 import { summarizePublishError } from "@/lib/publish-error";
 import { runCommand } from "@/lib/subprocess";
@@ -165,6 +165,7 @@ async function createAndPushRepo(projectDir: string, repoName: string, githubPat
 
   await git(["init", "-b", "main"]);
   await excludePlanforgeArtifactsFromPublish(projectDir);
+  await prunePublishedPlanforgeIndex(projectDir);
   await git(["config", "user.email", "forge@project-forge.dev"]);
   await git(["config", "user.name", "project-forge"]);
   await git(["add", "-A"]);

--- a/lib/planforge-output.ts
+++ b/lib/planforge-output.ts
@@ -211,3 +211,44 @@ export async function excludePlanforgeArtifactsFromPublish(projectDir: string): 
     : `${block}\n`;
   await fs.writeFile(excludePath, next);
 }
+
+// Reconcile the committed planforge-index.json with what actually ships. The
+// generation-only artifacts excludePlanforgeArtifactsFromPublish keeps out of the
+// commit (the whole planning/ directory + exports/scaffoldkit-input.json) are not
+// in the deliverable, so an agent or tool that trusts the index for path discovery
+// would 404 on those entries. Drop them from the SHIPPED index here. This must run
+// AFTER excludePlanforgeArtifactsFromPublish, which reads the complete index to
+// derive its patterns, so the generation-time index on disk stays intact for that.
+export async function prunePublishedPlanforgeIndex(projectDir: string): Promise<void> {
+  const indexPath = path.join(projectDir, "planforge-index.json");
+  const index = await readPlanforgeIndex(indexPath);
+  if (!index) {
+    return;
+  }
+
+  // exports/scaffoldkit-input.json is the only excluded exports entry; other
+  // exports (e.g. devreview, when planforge still emits it) ship and stay.
+  const exports: PathMap = { ...(index.exports ?? {}) };
+  delete exports.scaffoldkit;
+
+  const directories: PathMap = { ...(index.directories ?? {}) };
+  // The entire planning/ directory is excluded from publish.
+  delete directories.planning;
+  // exports/ is committed only when a non-excluded exports entry survives; if
+  // scaffoldkit-input.json was the only one, the directory is absent from the commit.
+  if (Object.keys(exports).length === 0) {
+    delete directories.exports;
+  }
+
+  // Preserve every other field (version, summary, context, rootFiles, ai,
+  // handoff, ...); only the excluded blocks are pruned. planning is emptied
+  // rather than deleted so the index keeps its documented shape.
+  const pruned = {
+    ...index,
+    directories,
+    planning: {},
+    exports,
+  };
+
+  await fs.writeFile(indexPath, `${JSON.stringify(pruned, null, 2)}\n`);
+}

--- a/lib/runtime-signals.ts
+++ b/lib/runtime-signals.ts
@@ -61,7 +61,17 @@ export async function collectRuntimePaths(rootDir: string, maxPaths = 60): Promi
   const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch(() => []);
   const topLevelPaths = entries
     .map((entry) => entry.name)
-    .filter((name) => !PLANFORGE_TOP_LEVEL_PATHS.has(name) && name !== ".git" && name !== "node_modules")
+    .filter(
+      (name) =>
+        !PLANFORGE_TOP_LEVEL_PATHS.has(name) &&
+        name !== ".git" &&
+        name !== "node_modules" &&
+        // forge-internal bookkeeping written during generation and removed before
+        // publish; never part of the deliverable, so it must not be snapshotted as
+        // runtime structure in the post-scaffold review.
+        name !== ".forge-meta.json" &&
+        name !== ".forge-published"
+    )
     .sort();
 
   const samplePaths: string[] = [];

--- a/tests/integration/planforge-output.test.ts
+++ b/tests/integration/planforge-output.test.ts
@@ -5,6 +5,7 @@ import * as os from "os";
 import * as path from "path";
 import {
   excludePlanforgeArtifactsFromPublish,
+  prunePublishedPlanforgeIndex,
   readScaffoldPreview,
   resolvePlanforgeOutputPaths,
 } from "../../lib/planforge-output";
@@ -116,6 +117,104 @@ describe("planforge publish exclusion", () => {
     expect(staged).not.toContain(".planforge/exports/scaffoldkit-input.json");
     expect(staged).toContain("README.md");
     expect(staged).toContain("planforge-index.json");
+  });
+
+  it("prunes excluded planning/exports entries from the shipped index, keeps the rest", async () => {
+    const tempDir = await makeTempDir();
+    tempDirs.push(tempDir);
+
+    await fs.mkdir(path.join(tempDir, "planning"), { recursive: true });
+    await fs.mkdir(path.join(tempDir, "exports"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, "planning", "plan-output.json"), "{}\n");
+    await fs.writeFile(path.join(tempDir, "exports", "scaffoldkit-input.json"), "{}\n");
+    await fs.writeFile(path.join(tempDir, "exports", "devreview.json"), "{}\n");
+    await fs.writeFile(path.join(tempDir, "README.md"), "# demo\n");
+    await fs.writeFile(
+      path.join(tempDir, "planforge-index.json"),
+      JSON.stringify(
+        {
+          generatedBy: "agent-planforge",
+          summary: "keep me",
+          rootFiles: { agents: "AGENTS.md" },
+          directories: { ai: ".ai", planning: "planning", exports: "exports", tasks: "tasks" },
+          planning: {
+            planOutput: "planning/plan-output.json",
+            structuredInput: "planning/structured-input.json",
+          },
+          exports: { scaffoldkit: "exports/scaffoldkit-input.json", devreview: "exports/devreview.json" },
+          ai: { agents: ".ai/AGENTS.md" },
+        },
+        null,
+        2
+      )
+    );
+
+    const git = (args: string[]) =>
+      execFileSync("git", args, { cwd: tempDir, stdio: "pipe" });
+    git(["init"]);
+    git(["config", "user.email", "t@example.com"]);
+    git(["config", "user.name", "t"]);
+
+    // Order is load-bearing: exclude reads the complete index, prune rewrites it after.
+    await excludePlanforgeArtifactsFromPublish(tempDir);
+    await prunePublishedPlanforgeIndex(tempDir);
+    git(["add", "-A"]);
+
+    const shipped = JSON.parse(
+      await fs.readFile(path.join(tempDir, "planforge-index.json"), "utf-8")
+    );
+
+    // Excluded entries are gone from the shipped index.
+    expect(shipped.planning).toEqual({});
+    expect(shipped.directories.planning).toBeUndefined();
+    expect(shipped.exports.scaffoldkit).toBeUndefined();
+    // A still-shipping export (devreview ships, so its dir entry stays) is kept.
+    expect(shipped.exports.devreview).toBe("exports/devreview.json");
+    expect(shipped.directories.exports).toBe("exports");
+    // Unrelated fields and other directories are preserved.
+    expect(shipped.summary).toBe("keep me");
+    expect(shipped.rootFiles.agents).toBe("AGENTS.md");
+    expect(shipped.directories.tasks).toBe("tasks");
+
+    const staged = execFileSync("git", ["ls-files"], { cwd: tempDir, encoding: "utf-8" })
+      .split("\n")
+      .filter(Boolean);
+    expect(staged).toContain("planforge-index.json");
+    expect(staged).toContain("exports/devreview.json");
+    expect(staged).not.toContain("planning/plan-output.json");
+    expect(staged).not.toContain("exports/scaffoldkit-input.json");
+  });
+
+  it("drops directories.exports from the shipped index when scaffoldkit-input was the only export", async () => {
+    const tempDir = await makeTempDir();
+    tempDirs.push(tempDir);
+
+    await fs.writeFile(
+      path.join(tempDir, "planforge-index.json"),
+      JSON.stringify(
+        {
+          generatedBy: "agent-planforge",
+          rootFiles: { agents: "AGENTS.md" },
+          directories: { ai: ".ai", planning: "planning", exports: "exports" },
+          planning: { planOutput: "planning/plan-output.json" },
+          exports: { scaffoldkit: "exports/scaffoldkit-input.json" },
+          ai: { agents: ".ai/AGENTS.md" },
+        },
+        null,
+        2
+      )
+    );
+
+    await prunePublishedPlanforgeIndex(tempDir);
+
+    const shipped = JSON.parse(
+      await fs.readFile(path.join(tempDir, "planforge-index.json"), "utf-8")
+    );
+    expect(shipped.exports).toEqual({});
+    expect(shipped.directories.exports).toBeUndefined();
+    expect(shipped.directories.planning).toBeUndefined();
+    expect(shipped.directories.ai).toBe(".ai");
+    expect(shipped.planning).toEqual({});
   });
 
   it("never emits a root exclude for a flat-layout index (root-guard)", async () => {

--- a/tests/integration/post-scaffold-review.test.ts
+++ b/tests/integration/post-scaffold-review.test.ts
@@ -195,6 +195,41 @@ describe("post-scaffold review artifact relocation", () => {
     expect(runtime?.status).toBe("warn");
     expect(review.verdict.status).not.toBe("ok");
   });
+
+  it("does not snapshot forge-internal bookkeeping (.forge-meta.json) as runtime structure", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "project-forge-forgemeta-"));
+    tempDirs.push(tempDir);
+
+    await fs.mkdir(path.join(tempDir, "tasks"), { recursive: true });
+    await fs.mkdir(path.join(tempDir, "src"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, "src", "main.py"), "print('ok')\n");
+    await fs.writeFile(
+      path.join(tempDir, "scaffoldkit-input.json"),
+      JSON.stringify(
+        {
+          projectName: "demo",
+          blueprint: "rest-api",
+          blueprintConfidence: "strong",
+          agentMustCreateStructure: false,
+        },
+        null,
+        2
+      )
+    );
+    // The two-phase generate->publish flow writes .forge-meta.json before the
+    // review runs; publish removes it, so it must not be snapshotted as
+    // deliverable runtime structure (that would advertise an absent path).
+    await fs.writeFile(path.join(tempDir, ".forge-meta.json"), JSON.stringify({ owner: "u" }));
+
+    await runPostScaffoldReview(tempDir);
+
+    const persisted = JSON.parse(
+      await fs.readFile(path.join(tempDir, ".planforge", "post-scaffold-review.json"), "utf-8")
+    );
+    expect(persisted.runtimeIndicators.topLevelPaths).not.toContain(".forge-meta.json");
+    // The filter is specific to bookkeeping: real source still registers.
+    expect(persisted.runtimeIndicators.topLevelPaths).toContain("src");
+  });
 });
 
 describe("post-scaffold review surfaces the blueprint-fit gate in the entry path", () => {


### PR DESCRIPTION
## Problem

After #79 (dangling-prose scrub) and #80 (planning/ exclude), the agent-facing prose docs are clean, but the machine artifacts shipped in the published repo still advertised paths that `excludePlanforgeArtifactsFromPublish` keeps out of the deliverable, so a tool that trusts them for path discovery would 404:
- `planforge-index.json`: `directories.planning` / `directories.exports`, the whole `planning.*` block, and `exports.scaffoldkit` all point at the excluded `planning/` dir and `exports/scaffoldkit-input.json`.
- `post-scaffold-review.json`: `topLevelPaths` snapshotted `.forge-meta.json`, the transient ownership file removed at publish.

## Change

- `prunePublishedPlanforgeIndex` rewrites the committed `planforge-index.json` after the exclude step (which reads the complete index to derive its patterns): drops the `planning` block + `directories.planning` and `exports.scaffoldkit`, keeps any still-shipping export (e.g. `devreview`), drops `directories.exports` only when no export survives, and preserves every other field. Wired into all three publish routes (`publish`, `v1/publish`, `v1/projects`) after the exclude and before `git add`.
- `collectRuntimePaths` (the shared runtime-signal scanner) now also filters `.forge-meta.json` / `.forge-published`, so the review no longer snapshots a path absent from the deliverable.

This is the project-forge-side reconciliation the finding recommended: project-forge owns what it excludes, so it sanitizes the machine artifacts it ships while leaving the generation-time index complete for the exclude derivation.

## Tests

`tsc` clean, `eslint` 0 errors, full `vitest` 105 passed. New tests: the index prune (excluded entries gone, `devreview` and other fields kept, `directories.exports` dropped only when empty) and the `.forge-meta.json` filter (absent from the persisted `topLevelPaths`, real source still registers). Review subagent: SHIP, no defects.

Refs: agent-tasks 90756a8b