### PR TITLE
chore(release): project-forge v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-01
+
+### Added
+
+- **Surface the wave-0 blueprint-fit gate at the front of the agent entry path.** When the post-scaffold review emits a blueprint-fit follow-up, the generated entry artifacts (`.ai/TASKS.md`, root `AGENTS.md`) now lead with `tasks/900`, so a fresh agent resolves the scaffold-vs-plan mismatch before starting wave-1 work (#81).
+
+### Changed
+
+- **Keep planforge generation-only artifacts out of the published deliverable.** The whole `planning/` directory and `exports/scaffoldkit-input.json` are excluded from the published repository, and a post-Phase-3 `planforge-index.json` that omits the `handoff` block is tolerated, so a published repo carries only what a consumer needs (#78, #79, #80).
+
+### Fixed
+
+- **Published machine artifacts no longer advertise excluded paths.** The shipped `planforge-index.json` is pruned of the excluded `planning/` and `exports/scaffoldkit-input.json` entries, and the post-scaffold review no longer snapshots the transient `.forge-meta.json`, so a tool that trusts the index for path discovery does not 404 (#84).
+- **Honest scaffold verdict and label.** The post-scaffold `runtime-structure-present` check and the preview "Full scaffold" label both require a real source file (by extension), so an empty scaffold (a manifest plus empty directories) is reported as a planning baseline instead of being over-claimed as a full scaffold (#82, #83).
+
 ## [0.4.0] - 2026-06-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-forge",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Cut project-forge **v0.5.0** (from v0.4.0).

## Changes since v0.4.0

- **Added** surfacing of the wave-0 blueprint-fit gate at the front of the agent entry path (#81)
- **Changed** to keep planforge generation-only artifacts out of the published deliverable and tolerate a `handoff`-less post-Phase-3 index (#78, #79, #80)
- **Fixed** the shipped `planforge-index.json` / post-scaffold review so they no longer advertise excluded paths (#84)
- **Fixed** the scaffold verdict and "Full scaffold" label to require a real source file, so an empty scaffold is reported as a planning baseline (#82, #83)

## Verification

`vitest` 105 passed, `tsc` + `eslint` clean. Dogfooded end-to-end on the live stack (r6/r7/r8 generated repos, fresh-implementer `canMakeProgress=true`). Review subagent: SHIP.

Tagging `v0.5.0` after merge triggers the release workflow (CI + GitHub Release).

Refs: agent-tasks 8e880055