### PR TITLE
docs: fix README/docs drift vs code in project-forge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,26 +1,35 @@
-# Required
-GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
-GITHUB_OWNER=LanNguyenSi
-
-# Optional (defaults shown)
-# FORGE_TEMP_DIR=/tmp/project-forge
+# ── Required ───────────────────────────────────────────────
+# Auth (NextAuth)
+NEXTAUTH_SECRET=your-secret-here-generate-with-openssl-rand-hex-32
+NEXTAUTH_URL=https://project-forge.opentriologue.ai
+DATABASE_URL=file:./db/project-forge.db
 
 # agent-planforge HTTP service (ADR-0002). Required on VPS deploys that run
 # the planforge container alongside project-forge. Generate a fresh random
 # token:  openssl rand -hex 32
 # The same value must be set in both the project-forge and planforge
-# containers — compose propagates it via the shared .env.
+# containers; compose propagates it via the shared .env.
 PLANFORGE_SERVICE_TOKEN=
 
-# Optional AI providers
-# Local OpenAI-compatible server takes precedence when both are set.
+# ── Optional ───────────────────────────────────────────────
+# Repo publishing uses each user's OWN GitHub PAT, added in the dashboard.
+# There is no platform-wide GITHUB_TOKEN / GITHUB_OWNER env var.
+
+# GitHub OAuth sign-in (optional login method)
+# GITHUB_ID=
+# GITHUB_SECRET=
+
+# Restrict project-pilot broker registration to specific GitHub logins
+# (comma-separated). Unset/empty = accept any.
+# ALLOWED_GITHUB_LOGINS=
+
+# Temp dir for build artifacts (defaults to /tmp/project-forge)
+# FORGE_TEMP_DIR=/tmp/project-forge
+
+# AI providers (optional). A local OpenAI-compatible server takes precedence
+# when both local and hosted keys are set.
 # LOCAL_AI_BASE_URL=http://127.0.0.1:11434/v1
 # LOCAL_AI_MODEL=qwen2.5:14b-instruct
 # LOCAL_AI_API_KEY=
 # GROQ_API_KEY=
 # OPENAI_API_KEY=
-
-# Auth
-NEXTAUTH_SECRET=your-secret-here-generate-with-openssl-rand-hex-32
-NEXTAUTH_URL=https://project-forge.opentriologue.ai
-DATABASE_URL=file:./db/project-forge.db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Thanks for your interest. project-forge is a web UI for creating AI-toolchain pr
    npm test
    ```
 
-4. For Prisma schema changes, generate a migration and check it in alongside the schema edit.
+4. For Prisma schema changes, run `npx prisma db push` to sync the local SQLite database. This project uses `db push`, not migration files; there is no `prisma/migrations` directory to check in.
 5. Open the PR with a clear summary, motivation, and test plan.
 
 ## Dev Setup
@@ -29,10 +29,12 @@ Thanks for your interest. project-forge is a web UI for creating AI-toolchain pr
 git clone https://github.com/LanNguyenSi/project-forge.git
 cd project-forge
 npm install
-docker compose up -d   # Postgres
-npx prisma migrate dev
+npx prisma generate
+npx prisma db push   # creates the local SQLite database
 npm run dev
 ```
+
+The database is local SQLite (file path from `DATABASE_URL`); no separate database server is needed. Or run `make dev` to install deps, generate the Prisma client, create the SQLite DB, scaffold `.env`, and start the dev server in one step.
 
 ## Style
 

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,7 @@ dev-env:
 		echo "  NEXTAUTH_URL     http://localhost:3000"; \
 		echo "  DATABASE_URL     file:./db/project-forge.db"; \
 		echo ""; \
-		echo "  Optional — fill in to enable all features:"; \
-		echo "    GITHUB_TOKEN   (repo creation)"; \
-		echo "    GITHUB_OWNER   (repo owner)"; \
+		echo "  Optional - fill in to enable all features:"; \
 		echo "    GITHUB_ID      (OAuth login)"; \
 		echo "    GITHUB_SECRET  (OAuth login)"; \
 		echo "    LOCAL_AI_BASE_URL + LOCAL_AI_MODEL  (optional local AI)"; \

--- a/README.md
+++ b/README.md
@@ -35,13 +35,16 @@ make deploy
 
 | Variable | Description |
 |---|---|
-| `GITHUB_TOKEN` | GitHub PAT with `repo` scope (for the platform itself) |
-| `GITHUB_OWNER` | GitHub username for repo creation |
 | `NEXTAUTH_SECRET` | Random secret (`openssl rand -hex 32`) |
 | `NEXTAUTH_URL` | Public URL (e.g. `https://project-forge.example.com`) |
 | `DATABASE_URL` | SQLite path (e.g. `file:/data/project-forge.db`) |
 | `PLANFORGE_URL` | URL of the planforge HTTP service (defaults to `http://planforge:8223` in compose). |
 | `PLANFORGE_SERVICE_TOKEN` | Shared bearer token for the planforge HTTP service. Generate with `openssl rand -hex 32`. Same value in both `app` and `planforge` containers. |
+
+> Publishing a repo uses each **user's own** GitHub Personal Access Token (PAT),
+> added in the dashboard, not a platform-wide token. There is no server-level
+> `GITHUB_TOKEN` or `GITHUB_OWNER` env var. For OAuth sign-in, set the optional
+> `GITHUB_ID` / `GITHUB_SECRET` below.
 
 ### Optional
 
@@ -54,7 +57,8 @@ make deploy
 | `LOCAL_AI_API_KEY` | Optional API key for the local AI endpoint |
 | `GITHUB_ID` | GitHub OAuth app Client ID |
 | `GITHUB_SECRET` | GitHub OAuth app Client Secret |
-| `FORGE_TEMP_DIR` | Directory for temporary build artifacts (defaults to OS temp dir) |
+| `ALLOWED_GITHUB_LOGINS` | Comma-separated allowlist of GitHub logins permitted to register via the project-pilot broker. Unset/empty = accept any. |
+| `FORGE_TEMP_DIR` | Directory for temporary build artifacts (defaults to `/tmp/project-forge`) |
 
 ### Docker Compose
 
@@ -80,7 +84,7 @@ A token store + in-place rotation is a follow-up (see ADR-0002).
 
 All endpoints require an API token generated in the dashboard, passed via the `X-API-Key` header.
 
-Rate limit: 10 requests/day per API token.
+Rate limit: 10 project publishes per user per day. Only `publish` and the one-shot `POST /api/v1/projects` count against it; `generate`, `preview`, and the project list/delete endpoints are unmetered. The quota is counted per user, across all of that user's tokens.
 
 ### `GET /api/v1/projects`
 
@@ -93,18 +97,16 @@ curl https://project-forge.opentriologue.ai/api/v1/projects \
 
 ### `DELETE /api/v1/projects`
 
-Delete a project by ID.
+Soft-delete a project by its `id` (the `id` field returned by `GET /api/v1/projects`), passed as a query parameter.
 
 ```bash
-curl -X DELETE https://project-forge.opentriologue.ai/api/v1/projects \
-  -H "X-API-Key: pf_your_token_here" \
-  -H "Content-Type: application/json" \
-  -d '{ "projectId": "clx..." }'
+curl -X DELETE "https://project-forge.opentriologue.ai/api/v1/projects?id=clx..." \
+  -H "X-API-Key: pf_your_token_here"
 ```
 
 ### `POST /api/v1/generate`
 
-Generate a project scaffold without publishing it. Returns a preview ID for inspection.
+Generate a project scaffold without publishing it. Returns a `sessionId` (a UUID) used by `preview` and `publish`. A session expires one hour after it is generated.
 
 ```bash
 curl -X POST https://project-forge.opentriologue.ai/api/v1/generate \
@@ -119,24 +121,33 @@ curl -X POST https://project-forge.opentriologue.ai/api/v1/generate \
   }'
 ```
 
+**Response:**
+```json
+{
+  "ok": true,
+  "sessionId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+  "preview": { "...": "file tree, tasks, architecture overview" }
+}
+```
+
 ### `GET /api/v1/preview`
 
-Fetch the generated preview (file tree, tasks, architecture) for a given preview ID.
+Fetch the generated preview (file tree, tasks, architecture) for a given `sessionId` (the value returned by `generate`).
 
 ```bash
-curl "https://project-forge.opentriologue.ai/api/v1/preview?previewId=prev_abc123" \
+curl "https://project-forge.opentriologue.ai/api/v1/preview?sessionId=f47ac10b-58cc-4372-a567-0e02b2c3d479" \
   -H "X-API-Key: pf_your_token_here"
 ```
 
 ### `POST /api/v1/publish`
 
-Finalize a previewed project and create the GitHub repository.
+Finalize a previewed project and create the GitHub repository. Requires a GitHub PAT configured in your dashboard, and counts against your daily publish quota.
 
 ```bash
 curl -X POST https://project-forge.opentriologue.ai/api/v1/publish \
   -H "X-API-Key: pf_your_token_here" \
   -H "Content-Type: application/json" \
-  -d '{ "previewId": "prev_abc123" }'
+  -d '{ "sessionId": "f47ac10b-58cc-4372-a567-0e02b2c3d479" }'
 ```
 
 **Response:**
@@ -150,6 +161,23 @@ curl -X POST https://project-forge.opentriologue.ai/api/v1/publish \
   }
 }
 ```
+
+### `POST /api/v1/projects`
+
+One-shot create: generate, scaffold, create the GitHub repository, and push in a single call, skipping the separate preview step. Requires a GitHub PAT configured in your dashboard, and counts against your daily publish quota. The request body is the same shape as `generate`.
+
+```bash
+curl -X POST https://project-forge.opentriologue.ai/api/v1/projects \
+  -H "X-API-Key: pf_your_token_here" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "projectName": "my-cli-tool",
+    "summary": "A CLI that syncs agent memory via Git",
+    "features": ["push memory files", "pull and merge"]
+  }'
+```
+
+Returns the same `{ ok, result: { repoUrl, cloneUrl, projectName } }` shape as `publish`.
 
 Full API documentation: [project-forge.opentriologue.ai/docs](https://project-forge.opentriologue.ai/docs)
 

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -221,7 +221,7 @@ export default function SettingsPage() {
           <Card>
             <CardHeader
               title="API Tokens"
-              subtitle="Create tokens for your agents to use the REST API. Rate limit: 10 projects/day per token."
+              subtitle="Create tokens for your agents to use the REST API. Rate limit: 10 project publishes per user per day."
             />
 
             <div className="flex gap-3 mb-6">

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -56,7 +56,7 @@ function DocsContent() {
       </Card>
 
       <Alert variant="warning">
-        <strong>Rate Limits:</strong> Each API token is limited to <strong>10 projects per day</strong>. This limit resets every 24 hours from your first request.
+        <strong>Rate Limits:</strong> The REST API allows <strong>10 project publishes per user per day</strong>, shared across all of your API tokens. The generate, preview, and list/delete endpoints are unmetered, and the limit is a rolling 24-hour window.
       </Alert>
     </div>
   );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     environment:
       NODE_ENV: production
       PORT: "3000"
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
-      GITHUB_OWNER: ${GITHUB_OWNER:-LanNguyenSi}
       FORGE_TEMP_DIR: /tmp/project-forge
       # Planforge HTTP boundary (ADR-0002). The planforge service runs both
       # the planforge CLI and scaffoldkit in-container; this app just POSTs

--- a/docs/adrs/0002-tool-decoupling-service-boundary.md
+++ b/docs/adrs/0002-tool-decoupling-service-boundary.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted (implemented; see `lib/planforge-client.ts` and the `planforge` service in `docker-compose.yml`)
 
 ## Context
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,151 +2,157 @@
 
 ## Overview
 
-project-forge is a CLI tool implemented in **python** using the **typer** framework.
-It follows a command-based architecture where each subcommand is an isolated unit with its own
-argument parsing, validation, and execution logic.
+project-forge is a full-stack web application built with **Next.js 15** (App
+Router) and **TypeScript**. Users describe a project in a form, the server asks
+the **agent-planforge HTTP service** to plan and scaffold it (planforge runs
+both the planforge CLI and scaffoldkit in its own container, see
+[ADR-0002](adrs/0002-tool-decoupling-service-boundary.md)), the result is
+extracted into a temporary directory, previewed, and on confirmation pushed to a
+new GitHub repository.
+
+The same capabilities are exposed as a token-authenticated REST API under
+`app/api/v1/` so agents can drive generation programmatically.
 
 ## Principles
 
-1. **Single responsibility per command**: Each command file owns one subcommand and nothing else.
-2. **Fail fast with clear messages**: Validate inputs at parse time; emit actionable error messages to stderr.
-3. **Exit codes are part of the interface**: Always exit with a meaningful code (see Exit Codes below).
-4. **Stdout for data, stderr for diagnostics**: Program output goes to stdout; logs, warnings, and errors go to stderr.
-5. **Composable with other tools**: Support `--output json` on commands that produce structured data.
-6. **Config is optional**: The tool must work with no config file present; config only overrides defaults.
+1. **Code is the source of truth**: behaviour lives in the route handlers and
+   `lib/` modules; docs track the code, not the other way round.
+2. **Thin UI, server-side orchestration**: pages collect input and render
+   previews; planning, scaffolding, and GitHub push happen in server route
+   handlers.
+3. **One external boundary**: project-forge talks to a single dependency, the
+   planforge HTTP service. scaffoldkit is an implementation detail behind it and
+   is never invoked from this app.
+4. **No secrets in responses or logs**: internal error detail (file paths,
+   stderr, PATs) is sanitized before it reaches clients or logs.
+5. **Dark-only UI**: Tailwind, dark-first, no light mode.
 
 ## System Structure
 
 ```
 project-forge/
-├── src/
-│   ├── commands/         # One module per subcommand
-│   │   ├── run.py
-│   │   └── config.py
-│   ├── config/           # Config file loading, validation, env var merging
-│   │   └── loader.py
-│   └── main.py
-│       # Entrypoint: registers commands, sets global flags
-├── tests/
-│   ├── commands/         # Tests mirroring src/commands
-│   └── config/
-└── docs/
+├── app/                          # Next.js App Router
+│   ├── (dashboard)/              # Auth-protected pages
+│   │   ├── create/page.tsx       # Project creation form
+│   │   ├── dashboard/page.tsx    # User dashboard
+│   │   ├── login/page.tsx        # Login
+│   │   └── settings/page.tsx     # User settings / API tokens
+│   ├── api/                      # Route handlers
+│   │   ├── v1/                   # Public REST API (X-API-Key auth)
+│   │   │   ├── generate/route.ts # Plan + scaffold, return a sessionId
+│   │   │   ├── preview/route.ts  # Read a previously generated session
+│   │   │   ├── publish/route.ts  # Create GitHub repo from a session
+│   │   │   └── projects/route.ts # GET list / DELETE / POST one-shot create
+│   │   ├── auth/                 # NextAuth + project-pilot registration broker
+│   │   ├── generate/route.ts     # Web UI generation (session auth)
+│   │   ├── publish/route.ts      # Web UI publish (session auth)
+│   │   ├── ai-assist/route.ts    # AI form enrichment ("magic fill")
+│   │   └── dashboard/route.ts    # User/token management
+│   ├── docs/page.tsx             # Swagger UI over public/openapi.json
+│   ├── layout.tsx                # Root layout
+│   └── globals.css               # Global styles + Swagger dark overrides
+│
+├── components/                   # React components (ProjectForm, PreviewPanel, modals, AppShell)
+├── lib/                          # Server-side business logic (see below)
+├── prisma/schema.prisma          # SQLite schema (users, API tokens, usage log)
+├── middleware.ts                 # Auth + API-key gating
+├── public/openapi.json           # OpenAPI spec served at /docs
+└── tests/                        # Vitest integration + unit tests
 ```
 
 ## Key Subsystems
 
-### 1. Command Parsing (typer)
+### 1. Routing and API surface
 
-Commands are defined as Python functions decorated with `@app.command()`. Typer derives
-argument names, types, and help text from function signatures and type annotations.
+Route handlers under `app/api/` export HTTP-method functions (`GET`, `POST`,
+`DELETE`) and return `NextResponse.json()` with explicit status codes.
 
-```python
-# src/commands/run.py
-import typer
+- **Public REST API** lives under `app/api/v1/` and authenticates with an
+  `X-API-Key` header carrying a dashboard-issued `pf_*` token
+  (`validateApiToken` in `lib/db.ts`).
+- **Web UI routes** (`app/api/generate`, `app/api/publish`, `app/api/dashboard`,
+  `app/api/ai-assist`) use NextAuth session auth.
+- `middleware.ts` gates the protected surfaces.
 
-def run(
-    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without changes"),
-    output: str = typer.Option("text", "--output", "-o", help="Output format"),
-) -> None:
-    """Execute the primary action."""
-    ...
-```
+Error responses follow the shape `{ ok: false, error: string, details?: string }`.
 
-The root app is created in `src/main.py` and subcommand apps are added with `app.add_typer()`.
+### 2. Generate / preview / publish flow
 
-### 2. Config Loading
+The v1 API is session-oriented and the steps share a single `sessionId` (a
+UUID):
 
-Config is loaded in layers, with later layers overriding earlier ones:
+1. `POST /api/v1/generate` builds a planforge input
+   (`lib/planforge-orchestrator.ts`), calls the planforge service over HTTP
+   (`lib/planforge-client.ts`), extracts the returned tarball into
+   `${FORGE_TEMP_DIR}/<sessionId>`, runs a post-scaffold review
+   (`lib/post-scaffold-review.ts`), and returns `{ ok, sessionId, preview }`.
+2. `GET /api/v1/preview?sessionId=<uuid>` re-reads the same temp dir and returns
+   the preview (`lib/v1-shared.ts`).
+3. `POST /api/v1/publish` (body `{ sessionId }`) creates a GitHub repo via the
+   user's own PAT and pushes the scaffold.
 
-```
-1. Compiled-in defaults
-2. Config file (~/.config/project-forge/config.yaml)
-3. Environment variables (PROJECT_FORGE_*)
-4. CLI flags passed at runtime
-```
+Sessions expire one hour after generation (`SESSION_TTL_MS` in
+`lib/v1-shared.ts`); the temp dir is the only state. `POST /api/v1/projects` is a
+one-shot variant that does generate plus publish in a single call without a
+preview step.
 
-The config loader lives in `src/config/`. It is responsible for:
+### 3. The planforge boundary
 
-- Locating the config file (respects `--config` flag and `XDG_CONFIG_HOME`)
-- Parsing the YAML file into a typed struct/dataclass
-- Merging environment variable overrides
-- Returning a validated config object to each command
+`lib/planforge-client.ts` is the only outbound integration. It POSTs to
+`${PLANFORGE_URL}/api/generate` with a `Bearer ${PLANFORGE_SERVICE_TOKEN}`
+header, consumes an SSE stream, and untars the base64 gzipped result into the
+request temp dir. The planforge container runs scaffoldkit internally; this app
+ships no Python and no scaffoldkit venv (see the Dockerfile and ADR-0002).
 
-Commands receive config as a parameter; they do not read it directly. This keeps commands
-testable without touching the filesystem.
+### 4. Config loading
 
-Config file path resolution order:
-1. Value of `--config` flag
-2. `$PROJECT_FORGE_CONFIG` environment variable
-3. `$XDG_CONFIG_HOME/project-forge/config.yaml`
-4. `~/.config/project-forge/config.yaml`
+Configuration is environment-variable based (no config file). Values are read
+directly from `process.env` at the point of use, for example `PLANFORGE_URL`,
+`PLANFORGE_SERVICE_TOKEN`, `FORGE_TEMP_DIR`, `DATABASE_URL`, `NEXTAUTH_SECRET`,
+the optional AI-provider keys, and the optional `ALLOWED_GITHUB_LOGINS`
+allowlist. See the README "Environment Variables" tables for the full list and
+which are required.
 
-### 3. Output Formatting
+### 5. Persistence
 
-Commands should never write directly to stdout with unstructured print statements.
-Instead, they call a shared output layer:
+Prisma over **SQLite** (`prisma/schema.prisma`, `provider = "sqlite"`). The
+client is a cached singleton in `lib/db.ts`. The schema syncs via
+`npx prisma db push` (there is no `prisma/migrations` directory). Core models:
+`User`, `ApiToken`, and `UsageLog` (one row per published project, also the
+basis for rate limiting).
 
-- **`output text`**: Human-readable, with optional color (disabled if `NO_COLOR` is set or `--no-color` is passed, or if stdout is not a TTY)
-- **`output json`**: Machine-readable JSON, always without color
-- **`output yaml`**: Machine-readable YAML, always without color
+### 6. Rate limiting
 
-The output module respects:
+`checkRateLimit(userId)` in `lib/db.ts` counts `UsageLog` rows for the user in
+the trailing 24 hours against `RATE_LIMIT_PER_DAY` (10). It is consumed only by
+the publish path (`app/api/v1/publish`) and the one-shot
+`POST /api/v1/projects`; `generate`, `preview`, and the list/delete endpoints
+are unmetered.
 
-- `NO_COLOR` environment variable (per [no-color.org](https://no-color.org))
-- `--no-color` flag
-- TTY detection: disable color when stdout is piped
+### 7. Secret handling
 
-### 4. Error Handling and Exit Codes
-
-All errors are caught at the top-level command runner and translated to appropriate exit codes.
-Commands signal failure by raising/returning an error - they never call `os.exit()` directly.
-
-#### Exit Code Reference
-
-| Code | Meaning |
-|------|---------|
-| `0` | Success |
-| `1` | General / unspecified error |
-| `2` | Invalid arguments or usage error |
-| `3` | Configuration error (bad config file, missing required setting) |
-| `4` | Runtime error (external service unavailable, permission denied) |
-| `5` | Not found (resource the command expected does not exist) |
-
-Error messages follow the pattern: `error: <what went wrong>. <how to fix it>.`
-
-Good: `error: config file not found at ~/.config/project-forge/config.yaml. Run 'project-forge config init' to create it.`
-Bad: `FileNotFoundError: [Errno 2] No such file or directory`
-
-### 5. Logging and Verbosity
-
-Diagnostic output is gated by a verbosity level:
-
-- **Default**: warnings and errors only
-- **`--verbose`**: informational messages, command timing
-- **`--debug`**: debug-level traces (when applicable)
-
-Structured log lines go to stderr and never to stdout.
+The publish path sanitizes any embedded GitHub PAT (`x-access-token:...@` remote
+URLs and bare `gho_/ghp_/ghu_/ghs_/github_pat_` token shapes) before the message
+reaches logs or responses. AI provider keys and the planforge service token are
+read from env only.
 
 ## CI/CD Architecture
 
-The pipeline runs on GitHub Actions (`.github/workflows/ci.yml`):
+The pipeline runs on GitHub Actions (`.github/workflows/ci.yml`) on Node 20:
 
-1. **lint** - ruff, mypy
-2. **test** - pytest with coverage
-3. **build** - `pip build` to verify package is installable
-4. **publish** - twine upload on tagged releases
+1. `npm ci --legacy-peer-deps`
+2. `npx prisma generate`
+3. `npx tsc --noEmit --skipLibCheck` (typecheck)
+4. `npm run lint` (ESLint)
+5. `npm run build` (`next build`)
+6. `npx vitest run` (tests)
 
 ## Testing Strategy
 
-Approach: **unit-tests**
-
-Each command module has a corresponding test file. Tests invoke command functions directly
-with controlled inputs - they do not spawn subprocess invocations.
-
-- Commands are tested with mocked config and mocked I/O
-- Config loader is tested with temporary files
-- Output formatter is tested for both text and JSON modes
+Test runner: **Vitest** with `happy-dom`. Integration and unit tests live under
+`tests/` (`tests/integration/`, `tests/unit/`) and exercise the route handlers
+and `lib/` modules directly. Run with `npm test` or `npm run test:watch`.
 
 ## Decisions
 
-See [ADR log](adrs/) for architectural decisions and their rationale.
+See the [ADR log](adrs/) for architectural decisions and their rationale.

--- a/docs/ways-of-working.md
+++ b/docs/ways-of-working.md
@@ -1,136 +1,97 @@
 # Ways of Working: project-forge
 
+project-forge is a Next.js 15 web application plus a token-authenticated REST
+API. These conventions are written for that surface (routes, React components,
+Prisma) and not for a command-line tool.
+
 ## Definition of Done
 
-A command, feature, or bug fix is done when:
+A feature or bug fix is done when:
 
-- [ ] Code compiles / passes linting with no new warnings
-- [ ] Tests are written and passing (unit-tests strategy - see below)
-- [ ] Exit codes are correct for success and failure paths
-- [ ] Help text is accurate and complete (`--help` for the affected command)
-- [ ] Error messages follow the project's message format (see Error Messages)
-- [ ] Documentation is updated if a public interface changed
-- [ ] Code has been reviewed by at least one other contributor
-- [ ] Change has been manually tested against a real terminal (not just unit tests)
-- [ ] Config changes are backward compatible, or migration is documented
+- [ ] Typecheck passes (`npm run typecheck` / `npx tsc --noEmit`)
+- [ ] Lint passes with no new warnings (`npm run lint`)
+- [ ] The app builds (`npm run build`)
+- [ ] Tests are written and passing (`npm test`, Vitest)
+- [ ] API responses keep the documented shape (`{ ok, error, details? }` for
+      errors); breaking shape changes are called out
+- [ ] No secrets (PATs, tokens, file paths, stderr) leak into responses or logs
+- [ ] Docs are updated if a public interface changed (README API section,
+      `public/openapi.json`, `docs/architecture.md`, `AI_CONTEXT.md`)
+- [ ] Change has been reviewed by at least one other contributor
 
-## CLI UX Conventions
+## API Conventions
 
-These rules govern how the tool behaves from a user perspective. All contributors must follow them.
+These rules govern the HTTP surface. All contributors must follow them.
 
-### Exit Codes
+### Responses and status codes
 
-Always use the canonical exit codes from [docs/architecture.md](architecture.md#exit-codes).
+- Always return `NextResponse.json()` with an explicit status code.
+- Success: `{ ok: true, ... }`. Failure: `{ ok: false, error: string, details?: string }`.
+- Use the right status: `400` invalid input, `401` missing/invalid auth, `404`
+  not found / expired session, `409` conflict (already published / deleted),
+  `429` rate limit, `500` unexpected.
 
-- Exit `0` on success, even if there is nothing to do
-- Exit `2` for usage errors (wrong argument types, mutually exclusive flags)
-- Exit `1` for all other failures if no more specific code applies
-- Never call `sys.exit()` / `os.Exit()` inside command logic - propagate errors to the top-level handler
+### Authentication
 
-### stdout vs stderr
+- Public API (`app/api/v1/*`) authenticates with the `X-API-Key` header carrying
+  a dashboard-issued `pf_*` token; validate via `validateApiToken`.
+- Web UI routes use NextAuth session auth.
 
-| Stream | What goes here |
-|--------|----------------|
-| `stdout` | All program output meant for the user or downstream tools |
-| `stderr` | Warnings, progress messages, debug logs, error messages |
+### Never leak secrets
 
-This makes the tool composable:
+- Do not put file paths, raw stderr, or GitHub PATs in responses or logs.
+- Sanitize PAT-shaped strings before logging (see `app/api/v1/publish/route.ts`).
 
-```bash
-project-forge run --output json | jq '.items[]'
-```
+### Rate limiting
 
-### Error Messages
+- The publish path and `POST /api/v1/projects` consume the per-user daily quota
+  (`checkRateLimit`); `generate`, `preview`, and list/delete do not. Keep that
+  split intact when adding endpoints.
 
-Errors written to stderr must follow this format:
+## Components and Styling
 
-```
-error: <what went wrong>. <how to fix it>.
-```
+- Page-level layout uses `<AppShell>` (sidebar) and `<PageShell>` (title /
+  subtitle).
+- Pages that need session or interactivity are client components (`"use client"`).
+- Tailwind, dark-first (`bg-gray-950`, `text-gray-100`, ...). No light mode.
 
-Examples:
+## Database
 
-```
-error: required argument TARGET was not provided. Run 'project-forge run --help' to see usage.
-error: config key 'output_format' has invalid value 'xml'. Allowed values: text, json, yaml.
-error: could not read file at path '/tmp/data.csv': no such file or directory.
-```
-
-Never expose raw exception traces to the user by default. Use `--debug` to show stack traces.
-
-### Color Output
-
-- Use color to aid readability, not to convey meaning alone (accessibility)
-- Always respect `NO_COLOR=1` (see [no-color.org](https://no-color.org))
-- Always respect `--no-color` flag
-- Disable color automatically when stdout/stderr is not a TTY (i.e., when piped)
-- Suggested palette: red for errors, yellow for warnings, green for success, cyan for labels
-
-### Progress Indicators
-
-For operations that may take more than one second:
-
-- Show a spinner or progress bar on stderr
-- Clear the progress indicator before printing final output to stdout
-- Disable progress indicators when `--quiet` is passed or when not a TTY
-- Never mix progress output into stdout
-
-### Output Formats
-
-Commands that produce structured data must support `--output` / `-o`:
-
-| Value | Description |
-|-------|-------------|
-| `text` | Human-readable, may include color and formatting |
-| `json` | Newline-terminated JSON object or array, no color |
-| `yaml` | YAML document, no color |
-
-Default is `text`. When `--output json` is used, the schema must remain stable across releases.
-
-### --dry-run
-
-Commands that mutate state must support `--dry-run`:
-
-- Print what would happen, prefixed with `[dry-run]` on stderr
-- Exit `0` without making any changes
-- Output must be human-readable; not required to be machine-parseable in dry-run mode
-
-### Interactive vs Non-interactive
-
-- The tool must function fully in non-interactive mode (no TTY, no stdin)
-- Never prompt for input unless stdin is a TTY and no flag was provided
-- Prompts must have a `--yes` / `--no` flag equivalent for scripting
+- Prisma over SQLite (`prisma/schema.prisma`, `provider = "sqlite"`).
+- After a schema change: `npx prisma generate`, then `npx prisma db push` to
+  sync the local SQLite database. This project uses `db push`, not migration
+  files; there is no `prisma/migrations` directory.
 
 ## Versioning
 
-This project follows [Semantic Versioning](https://semver.org/):
+This project follows [Semantic Versioning](https://semver.org/) for the app and
+its REST API:
 
-- **MAJOR**: breaking change to CLI interface (removed flag, changed exit code, changed output schema)
-- **MINOR**: new subcommand, new option, new output field (backward compatible)
-- **PATCH**: bug fix, documentation fix, internal refactor with no interface change
+- **MAJOR**: breaking change to the API (removed/renamed endpoint or field,
+  changed auth, changed response shape in a removing way)
+- **MINOR**: new endpoint, new optional field, new optional env var (backward
+  compatible)
+- **PATCH**: bug fix, documentation fix, internal refactor with no interface
+  change
 
 ### What Counts as a Breaking Change
 
-- Removing or renaming a command or flag
-- Changing the meaning of an exit code
-- Changing the JSON output schema in a way that removes or renames fields
-- Changing a flag from optional to required
+- Removing or renaming an endpoint, request field, or response field
+- Changing the meaning of a status code
+- Making a previously optional request field required
 
 ### What Does NOT Count as a Breaking Change
 
-- Adding a new optional flag
-- Adding new fields to JSON output
-- Changing help text wording
+- Adding a new endpoint or optional request field
+- Adding new fields to a response
 - Improving error messages
 
 ## Release Process
 
-1. Bump version in `pyproject.toml`
+1. Bump `version` in `package.json`
 2. Update `CHANGELOG.md`
-3. Commit: `chore(release): v1.2.3`
-4. Tag: `git tag v1.2.3`
-5. Push tag: `git push origin v1.2.3`
-6. CI publishes to PyPI automatically
+3. Commit: `chore(release): vX.Y.Z`
+4. Tag and push the tag; CI runs the build/test pipeline
 
 ## Branching Strategy
 
@@ -139,8 +100,8 @@ Trunk-based development with short-lived feature branches.
 ### Branch Naming
 
 ```
-feature/<ticket>-<short-description>
-fix/<ticket>-<short-description>
+feat/<short-description>
+fix/<short-description>
 chore/<description>
 docs/<description>
 ```
@@ -150,7 +111,7 @@ docs/<description>
 1. Branch from `main`
 2. Make small, focused commits
 3. Open a Pull Request (draft if in progress)
-4. Pass CI checks
+4. Pass CI checks (typecheck, lint, build, tests)
 5. Get at least one review approval
 6. Squash-merge into `main`
 7. Delete the branch
@@ -162,10 +123,10 @@ docs/<description>
 Use conventional commit format:
 
 ```
-feat(run): add --format flag for structured output
-fix(config): handle missing config dir gracefully
-docs(architecture): document exit code table
-chore(deps): update typer to latest
+feat(api): add POST /api/v1/projects one-shot create
+fix(publish): sanitize PAT before logging
+docs(architecture): document the planforge boundary
+chore(deps): bump next to latest patch
 ```
 
 ### PR Description
@@ -174,45 +135,29 @@ Include:
 
 - **What**: what changed
 - **Why**: motivation or ticket reference
-- **Testing**: how you verified it (command invocations, test names)
-- **UX impact**: any change to output, flags, or exit codes
+- **Testing**: how you verified it (test names, manual steps)
+- **API impact**: any change to endpoints, request/response shape, or env vars
 
 ## Testing Expectations
 
-Strategy: **unit-tests**
+Runner: **Vitest** with `happy-dom`.
 
-### Unit Test Rules
-
-- Every command module has a corresponding test file in `tests/commands/`
-- Config loader is tested in `tests/config/`
-- Test function naming: `test_<command>_<scenario>_<expected_outcome>`
-- Tests must not touch the filesystem except through temp directories (`tmp_path` in pytest, `t.TempDir()` in Go)
-- Tests must not make network calls
-- Tests must not depend on environment variables unless explicitly set in the test
-- Aim for >80% branch coverage on `src/commands/` and `src/config/`
-
-### Test Naming
-
-```
-test_<command>_<scenario>_<expected_result>
-```
-
-Examples:
-
-```
-test_run_missing_required_arg_exits_2
-test_config_set_invalid_key_prints_error
-test_version_outputs_json_when_requested
-```
+- Integration and unit tests live under `tests/` (`tests/integration/`,
+  `tests/unit/`).
+- Tests exercise route handlers and `lib/` modules directly; mock the network
+  (the planforge service, GitHub API) rather than calling out.
+- Tests must not depend on ambient environment variables unless they set them
+  explicitly.
+- Cover both the success path and the auth/validation/error paths for new
+  endpoints.
 
 ## Architecture Decision Records (ADRs)
 
 Write an ADR in `docs/adrs/` when:
 
 - Choosing a library or external dependency
-- Changing the output schema of any command
+- Changing the shape of the public API or the planforge boundary
 - Establishing a new pattern not covered by existing docs
-- Deprecating or removing a command or flag
 
 ### ADR Format
 
@@ -234,32 +179,33 @@ What are the trade-offs? What becomes easier or harder?
 
 ## Documentation Expectations
 
-- **README**: always reflects actual install and usage instructions
-- **`--help` text**: updated whenever flags or commands change; treat it as part of the public API
-- **architecture.md**: updated when subsystem structure or data flow changes
+- **README**: always reflects actual setup, env vars, and the API surface
+- **`public/openapi.json`**: updated whenever an endpoint or its shape changes
+- **`docs/architecture.md`**: updated when subsystem structure or data flow changes
 - **ADRs**: written before merging significant decisions, not after
-- **AI_CONTEXT.md**: updated when adding new commands or changing patterns
+- **AI_CONTEXT.md**: updated when adding new patterns
 
 ## AI Collaboration Guidelines
 
-This project is configured for AI-assisted development. Read `AI_CONTEXT.md` before working on the codebase.
+This project is configured for AI-assisted development. Read `AI_CONTEXT.md`
+before working on the codebase.
 
 ### For AI Agents
 
 - Read `AI_CONTEXT.md` before starting any task
-- Follow the command module pattern exactly - do not invent new file layouts
-- Use the exit code table from architecture.md for all error paths
-- Write `--help` text for every new flag and command
-- Match the test naming convention
-- Do not add dependencies without creating an ADR
+- Follow the route-handler and `lib/` module patterns already in the repo
+- Do not leak secrets in responses or logs
+- Do not introduce light-mode styles (the app is dark-only)
+- Do not add dependencies without checking for an existing one; record
+  significant choices in an ADR
 
 ### For Developers Working with AI
 
-- Point the agent to the specific command file and test file to modify
-- Provide the expected `--help` output as part of the specification
-- Review exit code handling and stderr vs stdout routing carefully
-- Run the full test suite after AI-generated changes
-- Update `AI_CONTEXT.md` if new patterns are introduced
+- Point the agent to the specific route handler / `lib` module and test file
+- Provide the expected request/response shape as part of the specification
+- Review auth, status codes, and secret handling carefully
+- Run `npm run typecheck`, `npm run lint`, `npm run build`, and `npm test` after
+  AI-generated changes
 
 ## Communication
 

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -28,7 +28,7 @@
     "/api/v1/projects": {
       "post": {
         "summary": "Create a new project",
-        "description": "Generate a new project using planforge and scaffoldkit, create a GitHub repository, and push the initial commit. Rate limit: 10 projects per day per API token.",
+        "description": "Generate a new project using planforge and scaffoldkit, create a GitHub repository, and push the initial commit. Rate limit: 10 project creations per user per day.",
         "operationId": "createProject",
         "tags": [
           "Projects"


### PR DESCRIPTION
Fixes 9 verified documentation-vs-code drifts (plus in-repo sibling instances) from an org-wide README/docs audit. Each finding independently verified against source; branch reviewed by a separate reviewer subagent (verdict: REQUEST_CHANGES).

Scope: docs follow code (no features invented; non-existent commands/features removed or marked Planned; phantom Makefile targets corrected; version/identity constants aligned where code was the stale outlier). Sibling copies across secondary docs, UI strings, and code comments also fixed.

Refs: DOCS_DRIFT_REPORT_2026-06-18