### PR TITLE
feat(ui): Forge design foundation (T-001)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ out/
 tsconfig.tsbuildinfo
 prisma/db/
 db/
+
+# orchestrator-workflow run state (local only)
+.ai/

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,62 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ── Forge design-system tokens ── */
+:root {
+  /* surface scale */
+  --forge-void:  #0B0D10;
+  --forge-iron:  #14181D;
+  --forge-steel: #222A32;
+  --forge-ash:   #8A93A0;
+  --forge-mist:  #E7ECF2;
+
+  /* accent palette */
+  --ember:      #F5641E;
+  --ember-soft: #FB7A33;
+  --gold:       #FFB02E;
+
+  /* semantic */
+  --success: #34D399;
+  --warning: #FBBF24;
+  --danger:  #FB7185;
+
+  /* --font-display, --font-sans, --font-mono are injected by next/font
+     via className on the <html> element (see app/layout.tsx) */
+}
+
+@layer base {
+  html {
+    background-color: var(--forge-void);
+    color: var(--forge-mist);
+  }
+  body {
+    font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
+  }
+}
+
+/* ── Heat utilities ── */
+
+/* Full heat gradient — apply as background */
+.heat-gradient {
+  background: linear-gradient(95deg, var(--ember), var(--gold));
+}
+
+/* Heat seam — thin ember→gold top edge line, works on rounded surfaces */
+.heat-seam {
+  position: relative;
+  overflow: hidden;
+}
+.heat-seam::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--ember), var(--gold));
+  pointer-events: none;
+}
+
 /* ── Swagger UI dark-mode overrides ── */
 .swagger-ui {
   --bg: #0a0a0f;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,25 @@
 import type { Metadata } from "next";
+import { Space_Grotesk, IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
 import "./globals.css";
 import { SessionProvider } from "@/components/SessionProvider";
+
+const spaceGrotesk = Space_Grotesk({
+  subsets: ["latin"],
+  weight: ["500", "700"],
+  variable: "--font-display",
+});
+
+const ibmPlexSans = IBM_Plex_Sans({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-sans",
+});
+
+const ibmPlexMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  variable: "--font-mono",
+});
 
 export const metadata: Metadata = {
   title: "project-forge",
@@ -10,7 +29,10 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html
+      lang="en"
+      className={`${spaceGrotesk.variable} ${ibmPlexSans.variable} ${ibmPlexMono.variable}`}
+    >
       <body className="antialiased">
         <SessionProvider>{children}</SessionProvider>
       </body>

--- a/app/styleguide/page.tsx
+++ b/app/styleguide/page.tsx
@@ -1,0 +1,415 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/primitives/Button";
+import { Card, CardHeader } from "@/components/ui/primitives/Card";
+import { Input, Textarea, Label } from "@/components/ui/primitives/Input";
+import { Badge } from "@/components/ui/primitives/Badge";
+import { Alert } from "@/components/ui/primitives/Alert";
+
+// ── Section wrapper ─────────────────────────────────────────────────────────
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-16">
+      <h2 className="font-display text-xl font-semibold text-forge-mist mb-6 pb-3 border-b border-forge-steel">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function SubSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="mb-8">
+      <h3 className="text-sm font-medium text-forge-ash uppercase tracking-widest mb-4">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+// ── Color swatch ─────────────────────────────────────────────────────────────
+interface SwatchProps {
+  name: string;
+  hex: string;
+  bg: string;
+  textColor?: string;
+}
+
+function Swatch({ name, hex, bg, textColor = "text-forge-mist" }: SwatchProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className={`h-14 w-full rounded-card ${bg} border border-forge-steel/40`} />
+      <div className={`text-xs font-medium ${textColor}`}>{name}</div>
+      <div className="text-xs text-forge-ash font-mono">{hex}</div>
+    </div>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+export default function StyleguidePage() {
+  const [alertOpen, setAlertOpen] = useState(true);
+  const [alertSuccessOpen, setAlertSuccessOpen] = useState(true);
+
+  return (
+    <div className="min-h-screen bg-forge-void px-6 py-12">
+      <div className="mx-auto max-w-5xl">
+
+        {/* Page header */}
+        <div className="mb-16">
+          <div className="heat-seam rounded-card bg-forge-iron p-8">
+            <h1 className="font-display text-3xl font-bold text-forge-mist mb-2">
+              Forge Design System
+            </h1>
+            <p className="text-forge-ash text-sm">
+              Visual language reference for project-forge — dark-only, ember-accented.
+            </p>
+            <div className="mt-4 flex gap-2">
+              <Badge variant="info">v1.0</Badge>
+              <Badge variant="default">dark-only</Badge>
+            </div>
+          </div>
+        </div>
+
+        {/* ── 1. Colors ───────────────────────────────────────────────────── */}
+        <Section title="Colors">
+          <SubSection title="Forge surface scale">
+            <div className="grid grid-cols-5 gap-4">
+              <Swatch name="forge.void"  hex="#0B0D10" bg="bg-forge-void border border-forge-steel" />
+              <Swatch name="forge.iron"  hex="#14181D" bg="bg-forge-iron" />
+              <Swatch name="forge.steel" hex="#222A32" bg="bg-forge-steel" />
+              <Swatch name="forge.ash"   hex="#8A93A0" bg="bg-forge-ash" textColor="text-forge-void" />
+              <Swatch name="forge.mist"  hex="#E7ECF2" bg="bg-forge-mist" textColor="text-forge-void" />
+            </div>
+          </SubSection>
+
+          <SubSection title="Accent palette">
+            <div className="grid grid-cols-5 gap-4">
+              <Swatch name="ember"       hex="#F5641E" bg="bg-ember"      textColor="text-forge-void" />
+              <Swatch name="ember.soft"  hex="#FB7A33" bg="bg-ember-soft" textColor="text-forge-void" />
+              <Swatch name="gold"        hex="#FFB02E" bg="bg-gold"       textColor="text-forge-void" />
+            </div>
+          </SubSection>
+
+          <SubSection title="Semantic">
+            <div className="grid grid-cols-5 gap-4">
+              <Swatch name="success" hex="#34D399" bg="bg-success" textColor="text-forge-void" />
+              <Swatch name="warning" hex="#FBBF24" bg="bg-warning" textColor="text-forge-void" />
+              <Swatch name="danger"  hex="#FB7185" bg="bg-danger"  textColor="text-forge-void" />
+            </div>
+          </SubSection>
+        </Section>
+
+        {/* ── 2. Typography ────────────────────────────────────────────────── */}
+        <Section title="Typography">
+          <SubSection title="Display — Space Grotesk (500, 700)">
+            <div className="space-y-3 bg-forge-iron rounded-card p-6">
+              <p className="font-display font-bold text-4xl text-forge-mist">Display Heading 4xl</p>
+              <p className="font-display font-bold text-3xl text-forge-mist">Display Heading 3xl</p>
+              <p className="font-display font-bold text-2xl text-forge-mist">Display Heading 2xl</p>
+              <p className="font-display font-semibold text-xl text-forge-mist">Display Heading xl</p>
+              <p className="font-display font-medium text-lg text-forge-mist">Display Heading lg</p>
+              <p className="font-display font-medium text-base text-forge-ash">Display base — secondary</p>
+            </div>
+          </SubSection>
+
+          <SubSection title="Body — IBM Plex Sans (400, 500, 600)">
+            <div className="space-y-3 bg-forge-iron rounded-card p-6">
+              <p className="font-sans font-semibold text-lg text-forge-mist">Semibold body — lg</p>
+              <p className="font-sans font-medium text-base text-forge-mist">Medium body — base. The quick brown fox jumps over the lazy dog.</p>
+              <p className="font-sans font-normal text-sm text-forge-mist">Regular body — sm. Crafted for legibility at small sizes in dense UIs.</p>
+              <p className="font-sans font-normal text-sm text-forge-ash">Muted body — forge.ash. Used for secondary copy and descriptions.</p>
+              <p className="font-sans font-normal text-xs text-forge-ash">Extra-small — xs. Labels, meta, timestamps.</p>
+            </div>
+          </SubSection>
+
+          <SubSection title="Mono — IBM Plex Mono (400, 500)">
+            <div className="space-y-3 bg-forge-iron rounded-card p-6">
+              <p className="font-mono font-medium text-sm text-forge-mist">Medium mono — npm run build</p>
+              <p className="font-mono font-normal text-sm text-forge-ash">Regular mono — const token = &apos;#F5641E&apos;;</p>
+              <p className="font-mono font-normal text-xs text-forge-ash">XS mono — 2026-06-19T08:00:00Z</p>
+            </div>
+          </SubSection>
+        </Section>
+
+        {/* ── 3. Button ────────────────────────────────────────────────────── */}
+        <Section title="Button">
+          <SubSection title="Variants — md size">
+            <div className="flex flex-wrap gap-3 items-center">
+              <Button variant="primary">Primary</Button>
+              <Button variant="secondary">Secondary</Button>
+              <Button variant="danger">Danger</Button>
+              <Button variant="success">Success</Button>
+              <Button variant="ghost">Ghost</Button>
+            </div>
+          </SubSection>
+
+          <SubSection title="Sizes">
+            <div className="flex flex-wrap gap-3 items-center">
+              <Button variant="primary" size="sm">Small</Button>
+              <Button variant="primary" size="md">Medium</Button>
+              <Button variant="primary" size="lg">Large</Button>
+            </div>
+          </SubSection>
+
+          <SubSection title="States">
+            <div className="flex flex-wrap gap-3 items-center">
+              <Button variant="primary" loading>Loading</Button>
+              <Button variant="secondary" loading>Loading</Button>
+              <Button variant="primary" disabled>Disabled</Button>
+              <Button variant="secondary" disabled>Disabled</Button>
+              <Button variant="ghost" disabled>Disabled</Button>
+            </div>
+          </SubSection>
+
+          <SubSection title="Block">
+            <div className="max-w-sm">
+              <Button variant="primary" block>Block Button</Button>
+            </div>
+          </SubSection>
+
+          <SubSection title="Focus ring (simulated)">
+            <div className="flex flex-wrap gap-3 items-center">
+              <Button
+                variant="primary"
+                className="ring-2 ring-ember ring-offset-2 ring-offset-forge-void"
+              >
+                Primary focused
+              </Button>
+              <Button
+                variant="secondary"
+                className="ring-2 ring-forge-steel ring-offset-2 ring-offset-forge-void"
+              >
+                Secondary focused
+              </Button>
+            </div>
+          </SubSection>
+        </Section>
+
+        {/* ── 4. Card ──────────────────────────────────────────────────────── */}
+        <Section title="Card">
+          <SubSection title="Tones">
+            <div className="grid grid-cols-2 gap-4">
+              <Card tone="default">
+                <CardHeader title="Default card" subtitle="bg-forge-iron surface" />
+                <p className="text-sm text-forge-ash">Primary raised surface for content blocks.</p>
+              </Card>
+              <Card tone="muted">
+                <CardHeader title="Muted card" subtitle="60% iron opacity" />
+                <p className="text-sm text-forge-ash">Subdued surface for secondary content.</p>
+              </Card>
+              <Card tone="accent">
+                <CardHeader title="Accent card" subtitle="ember tinted surface" />
+                <p className="text-sm text-forge-ash">Highlights primary actions or CTAs.</p>
+              </Card>
+              <Card tone="success">
+                <CardHeader title="Success card" subtitle="green tinted" />
+                <p className="text-sm text-forge-ash">Positive confirmation states.</p>
+              </Card>
+              <Card tone="warning">
+                <CardHeader title="Warning card" subtitle="gold tinted" />
+                <p className="text-sm text-forge-ash">Caution or review-required states.</p>
+              </Card>
+              <Card tone="danger">
+                <CardHeader title="Danger card" subtitle="danger tinted" />
+                <p className="text-sm text-forge-ash">Error or destructive action states.</p>
+              </Card>
+            </div>
+          </SubSection>
+
+          <SubSection title="Padding variants">
+            <div className="grid grid-cols-3 gap-4">
+              <Card padding="sm"><p className="text-xs text-forge-ash">Padding sm (p-4)</p></Card>
+              <Card padding="md"><p className="text-xs text-forge-ash">Padding md (p-5/p-6)</p></Card>
+              <Card padding="lg"><p className="text-xs text-forge-ash">Padding lg (p-6/p-8)</p></Card>
+            </div>
+          </SubSection>
+
+          <SubSection title="Card + heat seam">
+            <Card className="heat-seam">
+              <CardHeader title="Heat seam card" subtitle="Top edge ember→gold gradient" />
+              <p className="text-sm text-forge-ash">The heat-seam utility adds a 2px ember-to-gold gradient line at the top, compatible with rounded corners.</p>
+            </Card>
+          </SubSection>
+        </Section>
+
+        {/* ── 5. Input ─────────────────────────────────────────────────────── */}
+        <Section title="Input">
+          <SubSection title="Text input">
+            <div className="max-w-md space-y-4">
+              <div>
+                <Label>Default input</Label>
+                <Input placeholder="Placeholder text…" />
+              </div>
+              <div>
+                <Label required hint="(optional note)">Required field</Label>
+                <Input placeholder="Enter value…" defaultValue="" />
+              </div>
+              <div>
+                <Label>Disabled</Label>
+                <Input placeholder="Cannot edit" disabled />
+              </div>
+            </div>
+          </SubSection>
+
+          <SubSection title="Textarea">
+            <div className="max-w-md space-y-4">
+              <div>
+                <Label>Description</Label>
+                <Textarea placeholder="Describe your project…" rows={4} />
+              </div>
+              <div>
+                <Label>Disabled textarea</Label>
+                <Textarea placeholder="Read only" disabled rows={3} />
+              </div>
+            </div>
+          </SubSection>
+        </Section>
+
+        {/* ── 6. Badge ─────────────────────────────────────────────────────── */}
+        <Section title="Badge">
+          <SubSection title="Variants">
+            <div className="flex flex-wrap gap-3 items-center">
+              <Badge variant="default">Default</Badge>
+              <Badge variant="success">Success</Badge>
+              <Badge variant="warning">Warning</Badge>
+              <Badge variant="danger">Danger</Badge>
+              <Badge variant="info">Info</Badge>
+            </div>
+          </SubSection>
+
+          <SubSection title="With icons (simulated)">
+            <div className="flex flex-wrap gap-3 items-center">
+              <Badge variant="success">
+                <span aria-hidden>✓</span> Deployed
+              </Badge>
+              <Badge variant="warning">
+                <span aria-hidden>⚠</span> Review
+              </Badge>
+              <Badge variant="danger">
+                <span aria-hidden>✕</span> Failed
+              </Badge>
+              <Badge variant="info">
+                <span aria-hidden>★</span> Beta
+              </Badge>
+              <Badge variant="default">
+                v0.5.0
+              </Badge>
+            </div>
+          </SubSection>
+        </Section>
+
+        {/* ── 7. Alert ─────────────────────────────────────────────────────── */}
+        <Section title="Alert">
+          <SubSection title="Variants">
+            <div className="space-y-3 max-w-2xl">
+              <Alert variant="error">
+                <strong>Error:</strong> The scaffoldkit process failed. Check the logs for details.
+              </Alert>
+              <Alert variant="success">
+                <strong>Success:</strong> Project created and repository published successfully.
+              </Alert>
+              <Alert variant="warning">
+                <strong>Warning:</strong> Your API quota is at 80%. Consider upgrading your plan.
+              </Alert>
+              <Alert variant="info">
+                <strong>Info:</strong> Generation is in progress — this may take up to 30 seconds.
+              </Alert>
+            </div>
+          </SubSection>
+
+          <SubSection title="Dismissible (interactive)">
+            <div className="space-y-3 max-w-2xl">
+              {alertOpen && (
+                <Alert variant="error" onClose={() => setAlertOpen(false)}>
+                  <strong>Dismissible error</strong> — click &times; to close.
+                </Alert>
+              )}
+              {alertSuccessOpen && (
+                <Alert variant="success" onClose={() => setAlertSuccessOpen(false)}>
+                  <strong>Dismissible success</strong> — click &times; to close.
+                </Alert>
+              )}
+              {!alertOpen && !alertSuccessOpen && (
+                <p className="text-sm text-forge-ash italic">All alerts dismissed.</p>
+              )}
+            </div>
+          </SubSection>
+        </Section>
+
+        {/* ── 8. Heat gradient + seam ──────────────────────────────────────── */}
+        <Section title="Heat gradient + seam">
+          <SubSection title="Heat gradient (bg-heat / .heat-gradient)">
+            <div className="grid grid-cols-3 gap-4">
+              <div className="h-20 w-full rounded-card bg-heat flex items-center justify-center">
+                <span className="text-forge-void font-display font-bold text-sm">bg-heat</span>
+              </div>
+              <div className="h-20 w-full rounded-card heat-gradient flex items-center justify-center">
+                <span className="text-forge-void font-display font-bold text-sm">.heat-gradient</span>
+              </div>
+              <div className="h-20 w-full rounded-card bg-heat flex items-center justify-center opacity-60">
+                <span className="text-forge-void font-display font-bold text-sm">opacity-60</span>
+              </div>
+            </div>
+          </SubSection>
+
+          <SubSection title="Heat seam (.heat-seam)">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="heat-seam rounded-card bg-forge-iron p-5">
+                <p className="text-sm font-medium text-forge-mist">Card with heat seam</p>
+                <p className="text-xs text-forge-ash mt-1">2px ember→gold top edge</p>
+              </div>
+              <div className="heat-seam rounded-card bg-forge-steel p-5">
+                <p className="text-sm font-medium text-forge-mist">Steel surface + heat seam</p>
+                <p className="text-xs text-forge-ash mt-1">Works on any background</p>
+              </div>
+            </div>
+          </SubSection>
+
+          <SubSection title="Text gradient (CSS example)">
+            <p
+              className="font-display font-bold text-3xl"
+              style={{
+                background: "linear-gradient(95deg, #F5641E, #FFB02E)",
+                WebkitBackgroundClip: "text",
+                WebkitTextFillColor: "transparent",
+                backgroundClip: "text",
+              }}
+            >
+              Forge. Build. Ship.
+            </p>
+          </SubSection>
+        </Section>
+
+        {/* ── 9. Radius samples ────────────────────────────────────────────── */}
+        <Section title="Border radius">
+          <div className="flex flex-wrap gap-6 items-end">
+            <div className="text-center">
+              <div className="h-14 w-32 bg-forge-steel rounded-btn flex items-center justify-center">
+                <span className="text-xs text-forge-ash font-mono">rounded-btn</span>
+              </div>
+              <p className="text-xs text-forge-ash mt-2">4px — buttons &amp; inputs</p>
+            </div>
+            <div className="text-center">
+              <div className="h-14 w-32 bg-forge-steel rounded-card flex items-center justify-center">
+                <span className="text-xs text-forge-ash font-mono">rounded-card</span>
+              </div>
+              <p className="text-xs text-forge-ash mt-2">10px — cards</p>
+            </div>
+            <div className="text-center">
+              <div className="h-14 w-32 bg-forge-steel rounded-full flex items-center justify-center">
+                <span className="text-xs text-forge-ash font-mono">rounded-full</span>
+              </div>
+              <p className="text-xs text-forge-ash mt-2">9999px — badges / pills</p>
+            </div>
+          </div>
+        </Section>
+
+        {/* Footer */}
+        <footer className="mt-8 pt-6 border-t border-forge-steel text-xs text-forge-ash text-center">
+          Forge design system — project-forge v0.5.0 — dark-only
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/primitives/Alert.tsx
+++ b/components/ui/primitives/Alert.tsx
@@ -6,10 +6,10 @@ interface AlertProps {
 }
 
 const variantStyles: Record<NonNullable<AlertProps["variant"]>, string> = {
-  error: "border-l-red-500 bg-red-950/30 text-red-300",
-  success: "border-l-green-500 bg-green-950/20 text-green-300",
-  warning: "border-l-yellow-500 bg-yellow-950/20 text-yellow-300",
-  info: "border-l-blue-500 bg-blue-950/20 text-blue-300",
+  error:   "border-l-danger bg-danger/10 text-danger",
+  success: "border-l-success bg-success/10 text-success",
+  warning: "border-l-warning bg-warning/10 text-warning",
+  info:    "border-l-forge-ash bg-forge-steel text-forge-mist",
 };
 
 export function Alert({
@@ -20,7 +20,7 @@ export function Alert({
 }: AlertProps) {
   return (
     <div
-      className={`border-l-2 rounded-r-md pl-4 pr-4 py-3 text-sm ${variantStyles[variant]} ${className}`}
+      className={`border-l-2 rounded-r-btn pl-4 pr-4 py-3 text-sm ${variantStyles[variant]} ${className}`}
     >
       <div className="flex items-start gap-3">
         <div className="flex-1">{children}</div>

--- a/components/ui/primitives/Badge.tsx
+++ b/components/ui/primitives/Badge.tsx
@@ -9,7 +9,7 @@ const variantStyles: Record<NonNullable<BadgeProps["variant"]>, string> = {
   success: "bg-success/15 text-success",
   warning: "bg-warning/15 text-warning",
   danger:  "bg-danger/15 text-danger",
-  info:    "bg-gold/15 text-gold",
+  info:    "bg-forge-steel text-forge-mist",
 };
 
 export function Badge({ children, variant = "default", className = "" }: BadgeProps) {

--- a/components/ui/primitives/Badge.tsx
+++ b/components/ui/primitives/Badge.tsx
@@ -5,17 +5,17 @@ interface BadgeProps {
 }
 
 const variantStyles: Record<NonNullable<BadgeProps["variant"]>, string> = {
-  default: "bg-gray-800 text-gray-400",
-  success: "bg-green-950/60 text-green-400",
-  warning: "bg-yellow-950/60 text-yellow-400",
-  danger: "bg-red-950/60 text-red-400",
-  info: "bg-blue-950/60 text-blue-400",
+  default: "bg-forge-steel text-forge-ash",
+  success: "bg-success/15 text-success",
+  warning: "bg-warning/15 text-warning",
+  danger:  "bg-danger/15 text-danger",
+  info:    "bg-gold/15 text-gold",
 };
 
 export function Badge({ children, variant = "default", className = "" }: BadgeProps) {
   return (
     <span
-      className={`inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-xs font-medium ${variantStyles[variant]} ${className}`}
+      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ${variantStyles[variant]} ${className}`}
     >
       {children}
     </span>

--- a/components/ui/primitives/Button.tsx
+++ b/components/ui/primitives/Button.tsx
@@ -15,7 +15,7 @@ const variantStyles: Record<Variant, string> = {
   primary:
     "bg-ember text-forge-void hover:bg-ember-soft focus-visible:ring-ember",
   secondary:
-    "bg-forge-steel text-forge-mist hover:bg-forge-steel/70 hover:text-forge-mist focus-visible:ring-forge-steel",
+    "bg-forge-steel text-forge-mist hover:bg-forge-steel/70 hover:text-forge-mist focus-visible:ring-forge-ash",
   danger:
     "bg-danger/15 text-danger hover:bg-danger/25 focus-visible:ring-danger",
   ghost:

--- a/components/ui/primitives/Button.tsx
+++ b/components/ui/primitives/Button.tsx
@@ -10,17 +10,18 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   loading?: boolean;
 }
 
+// WCAG AA note: ember primary uses text-forge-void (#0B0D10 on #F5641E = 6.14:1 contrast)
 const variantStyles: Record<Variant, string> = {
   primary:
-    "bg-blue-600 text-white hover:bg-blue-500 focus-visible:ring-blue-500",
+    "bg-ember text-forge-void hover:bg-ember-soft focus-visible:ring-ember",
   secondary:
-    "bg-gray-800 text-gray-300 hover:bg-gray-700 hover:text-gray-100 focus-visible:ring-gray-500",
+    "bg-forge-steel text-forge-mist hover:bg-forge-steel/70 hover:text-forge-mist focus-visible:ring-forge-steel",
   danger:
-    "bg-red-950/60 text-red-300 hover:bg-red-950/80 focus-visible:ring-red-500",
+    "bg-danger/15 text-danger hover:bg-danger/25 focus-visible:ring-danger",
   ghost:
-    "text-gray-400 hover:text-gray-200 hover:bg-gray-800/60 focus-visible:ring-gray-500",
+    "text-forge-ash hover:text-forge-mist hover:bg-forge-steel/60 focus-visible:ring-forge-ash",
   success:
-    "bg-green-600 text-white hover:bg-green-500 focus-visible:ring-green-500",
+    "bg-success/15 text-success hover:bg-success/25 focus-visible:ring-success",
 };
 
 const sizeStyles: Record<Size, string> = {
@@ -48,9 +49,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         disabled={disabled || loading}
         className={`
-          inline-flex items-center justify-center gap-2 rounded-md font-medium
+          inline-flex items-center justify-center gap-2 rounded-btn font-medium
           transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
-          focus-visible:ring-offset-gray-950
+          focus-visible:ring-offset-forge-void
           disabled:cursor-not-allowed disabled:opacity-50
           ${variantStyles[variant]}
           ${sizeStyles[size]}

--- a/components/ui/primitives/Card.tsx
+++ b/components/ui/primitives/Card.tsx
@@ -6,12 +6,12 @@ interface CardProps {
 }
 
 const toneStyles: Record<NonNullable<CardProps["tone"]>, string> = {
-  default: "bg-gray-900/80",
-  muted: "bg-gray-900/40",
-  accent: "bg-blue-950/30",
-  success: "bg-green-950/25",
-  warning: "bg-yellow-950/25",
-  danger: "bg-red-950/25",
+  default: "bg-forge-iron",
+  muted:   "bg-forge-iron/60",
+  accent:  "bg-ember/10 border border-ember/20",
+  success: "bg-success/10 border border-success/20",
+  warning: "bg-warning/10 border border-warning/20",
+  danger:  "bg-danger/10 border border-danger/20",
 };
 
 const paddingStyles: Record<NonNullable<CardProps["padding"]>, string> = {
@@ -29,7 +29,7 @@ export function Card({
 }: CardProps) {
   return (
     <div
-      className={`rounded-md ${toneStyles[tone]} ${paddingStyles[padding]} ${className}`}
+      className={`rounded-card ${toneStyles[tone]} ${paddingStyles[padding]} ${className}`}
     >
       {children}
     </div>
@@ -46,9 +46,9 @@ export function CardHeader({ title, subtitle, action }: CardHeaderProps) {
   return (
     <div className="flex items-center justify-between mb-5">
       <div>
-        <h2 className="text-base font-semibold text-gray-100 tracking-tight">{title}</h2>
+        <h2 className="text-base font-semibold text-forge-mist tracking-tight">{title}</h2>
         {subtitle && (
-          <p className="text-sm text-gray-500 mt-0.5">{subtitle}</p>
+          <p className="text-sm text-forge-ash mt-0.5">{subtitle}</p>
         )}
       </div>
       {action}

--- a/components/ui/primitives/Input.tsx
+++ b/components/ui/primitives/Input.tsx
@@ -1,7 +1,7 @@
 import { InputHTMLAttributes, TextareaHTMLAttributes, forwardRef } from "react";
 
 const baseStyles =
-  "w-full rounded-md border-0 bg-gray-800 px-3.5 py-2 text-gray-100 placeholder-gray-500 ring-1 ring-inset ring-gray-700 transition-colors focus:ring-2 focus:ring-blue-500 focus:outline-none";
+  "w-full rounded-btn border-0 bg-forge-steel px-3.5 py-2 text-forge-mist placeholder-forge-ash ring-1 ring-inset ring-forge-steel/80 transition-colors focus:ring-2 focus:ring-ember focus:outline-none";
 
 type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
@@ -38,10 +38,10 @@ interface LabelProps {
 
 export function Label({ children, required, hint, className = "" }: LabelProps) {
   return (
-    <label className={`block text-sm font-medium text-gray-400 mb-1.5 ${className}`}>
+    <label className={`block text-sm font-medium text-forge-ash mb-1.5 ${className}`}>
       {children}
-      {required && <span className="text-red-400 ml-0.5">*</span>}
-      {hint && <span className="text-gray-600 text-xs ml-2">{hint}</span>}
+      {required && <span className="text-danger ml-0.5">*</span>}
+      {hint && <span className="text-forge-ash/60 text-xs ml-2">{hint}</span>}
     </label>
   );
 }

--- a/components/ui/primitives/Input.tsx
+++ b/components/ui/primitives/Input.tsx
@@ -41,7 +41,7 @@ export function Label({ children, required, hint, className = "" }: LabelProps) 
     <label className={`block text-sm font-medium text-forge-ash mb-1.5 ${className}`}>
       {children}
       {required && <span className="text-danger ml-0.5">*</span>}
-      {hint && <span className="text-forge-ash/60 text-xs ml-2">{hint}</span>}
+      {hint && <span className="text-forge-ash text-xs ml-2">{hint}</span>}
     </label>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,7 +6,37 @@ export default {
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        forge: {
+          void:  "#0B0D10",
+          iron:  "#14181D",
+          steel: "#222A32",
+          ash:   "#8A93A0",
+          mist:  "#E7ECF2",
+        },
+        ember: {
+          DEFAULT: "#F5641E",
+          soft:    "#FB7A33",
+        },
+        gold:    "#FFB02E",
+        success: "#34D399",
+        warning: "#FBBF24",
+        danger:  "#FB7185",
+      },
+      borderRadius: {
+        btn:  "4px",
+        card: "10px",
+      },
+      fontFamily: {
+        display: ["var(--font-display)", "sans-serif"],
+        sans:    ["var(--font-sans)", "ui-sans-serif", "system-ui", "sans-serif"],
+        mono:    ["var(--font-mono)", "ui-monospace", "monospace"],
+      },
+      backgroundImage: {
+        heat: "linear-gradient(95deg, #F5641E, #FFB02E)",
+      },
+    },
   },
   plugins: [],
 } satisfies Config;


### PR DESCRIPTION
## T-001: Forge design foundation

Part of the project-forge UI overhaul (run 2026-06-19). Establishes the bespoke dark "Forge" design system so the rest of the app retones through tokens.

**What:**
- Design tokens as CSS vars + Tailwind theme.extend: forge.void/iron/steel/ash/mist neutrals, ember (#F5641E) + gold (#FFB02E) molten accent, semantic emerald/amber/rose; btn 4px / card 10px radii; ember to gold heat gradient + heat-seam utility.
- Fonts via next/font: Space Grotesk (display), IBM Plex Sans (body), IBM Plex Mono (mono).
- The 5 primitives (Button/Card/Input/Badge/Alert) retoned to tokens; public APIs unchanged.
- New /styleguide reference route.

**Verification:** npm run build clean; 105/105 vitest pass; tsc 0 errors; eslint 0 errors. Primary button forge-void on ember = 6.14:1 (WCAG AA).

**Review:** reviewer subagent returned accept_with_notes; the three contrast findings were addressed inline (secondary focus ring to forge-ash, Badge info to neutral so it no longer collides with warning, Label hint raised to AA). Operator approved the styleguide design direction.

**Scope:** dark-only; no auth/API/screen changes (those are follow-up tasks T-002..T-009). Known gap: no UI component test infra exists in the repo, so validation is build + styleguide screenshot (documented in the run state).

Refs: project-forge UI overhaul (Forge), task T-001
