### PR TITLE
feat(ui): Forge shared chrome (T-002)

### DIFF
--- a/app/(dashboard)/login/page.tsx
+++ b/app/(dashboard)/login/page.tsx
@@ -4,8 +4,8 @@ export const dynamic = "force-dynamic";
 import { useState } from "react";
 import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import { Button, Input, Label, Alert } from "@/components/ui/primitives";
+import { PublicNav } from "@/components/layout/PublicNav";
 
 export default function LoginPage() {
   const router = useRouter();
@@ -60,20 +60,7 @@ export default function LoginPage() {
 
   return (
     <main className="min-h-screen bg-gray-950 text-gray-100">
-      {/* Top nav */}
-      <nav className="border-b border-gray-800/50 px-6 py-4">
-        <div className="flex items-center justify-between max-w-md mx-auto">
-          <Link href="/" className="flex items-center gap-2.5">
-            <div className="h-8 w-8 rounded-md bg-blue-600 flex items-center justify-center text-white font-bold text-sm">
-              PF
-            </div>
-            <span className="font-semibold tracking-tight">project-forge</span>
-          </Link>
-          <Link href="/docs" className="text-sm text-gray-400 hover:text-gray-200 transition">
-            API Docs
-          </Link>
-        </div>
-      </nav>
+      <PublicNav />
 
       <div className="flex flex-1 items-center justify-center px-4 py-12 sm:py-20">
         <div className="w-full max-w-md space-y-6">

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import Link from "next/link";
 import { useSession } from "next-auth/react";
 import "swagger-ui-react/swagger-ui.css";
 import { AppShell } from "@/components/layout/AppShell";
 import { PageShell } from "@/components/ui/PageShell";
 import { Card, CardHeader, Alert } from "@/components/ui/primitives";
+import { PublicNav } from "@/components/layout/PublicNav";
 
 const SwaggerUI = dynamic(() => import("swagger-ui-react"), { ssr: false });
 
@@ -79,25 +79,7 @@ export default function ApiDocsPage() {
   // Public view — standalone layout without sidebar
   return (
     <main className="min-h-screen bg-gray-950 text-gray-100">
-      <nav className="border-b border-gray-800/50 px-6 py-4">
-        <div className="flex items-center justify-between max-w-7xl mx-auto">
-          <Link href="/" className="flex items-center gap-2.5">
-            <div className="h-8 w-8 rounded-md bg-blue-600 flex items-center justify-center text-white font-bold text-sm">
-              PF
-            </div>
-            <span className="font-semibold text-lg tracking-tight">project-forge</span>
-          </Link>
-          <div className="flex items-center gap-4 text-sm">
-            <Link href="/login" className="text-gray-400 hover:text-gray-200 transition">Login</Link>
-            <Link
-              href="/login"
-              className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-500 transition font-medium"
-            >
-              Get Started
-            </Link>
-          </div>
-        </div>
-      </nav>
+      <PublicNav />
 
       <div className="px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
         <div className="mx-auto max-w-7xl">

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,5 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <!-- Forge-iron background with rounded corners -->
   <rect width="32" height="32" rx="4" fill="#14181D"/>
   <defs>
     <linearGradient id="fg" x1="16" y1="27" x2="17" y2="3" gradientUnits="userSpaceOnUse">
@@ -7,8 +6,6 @@
       <stop offset="100%" stop-color="#FFB02E"/>
     </linearGradient>
   </defs>
-  <!-- Ember flame mark -->
   <path d="M16 4.5C12.5 11 9.5 12 11 18C12.5 22.5 16 24 16 24C16 24 19.5 22.5 21 18C22.5 12 19.5 11 16 4.5Z" fill="url(#fg)"/>
-  <!-- Hot core highlight -->
   <path d="M16 18C15 16 14.7 14 16 13C17.3 14 17 16 16 18Z" fill="#FFB02E" fill-opacity="0.4"/>
 </svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,6 @@ const ibmPlexMono = IBM_Plex_Mono({
 export const metadata: Metadata = {
   title: "project-forge",
   description: "Create AI-toolchain projects with planforge + scaffoldkit",
-  icons: { icon: "/favicon.svg" },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+import { PublicNav } from "@/components/layout/PublicNav";
 
 const features = [
   {
@@ -63,31 +64,7 @@ export default function LandingPage() {
 
   return (
     <main className="min-h-screen bg-gray-950 text-gray-100">
-      {/* Nav */}
-      <nav className="border-b border-gray-800/50 px-6 py-4">
-        <div className="flex items-center justify-between max-w-6xl mx-auto">
-          <div className="flex items-center gap-2.5">
-            <div className="h-8 w-8 rounded-md bg-blue-600 flex items-center justify-center text-white font-bold text-sm">
-              PF
-            </div>
-            <span className="font-semibold text-lg tracking-tight">project-forge</span>
-          </div>
-          <div className="flex items-center gap-6 text-sm">
-            <Link href="/docs" className="text-gray-400 hover:text-gray-200 transition">
-              Docs
-            </Link>
-            <Link href="/login" className="text-gray-400 hover:text-gray-200 transition">
-              Login
-            </Link>
-            <Link
-              href="/login"
-              className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-500 transition font-medium"
-            >
-              Get Started
-            </Link>
-          </div>
-        </div>
-      </nav>
+      <PublicNav />
 
       {/* Hero */}
       <section className="max-w-4xl mx-auto px-6 py-24 text-center">

--- a/components/DialogShell.tsx
+++ b/components/DialogShell.tsx
@@ -99,7 +99,7 @@ export function DialogShell({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-forge-void/70 p-4 backdrop-blur-sm"
       onClick={onClose}
     >
       <div
@@ -108,7 +108,7 @@ export function DialogShell({
         aria-modal="true"
         aria-labelledby={titleId}
         tabIndex={-1}
-        className="w-full max-w-md rounded-md bg-gray-900 p-8 shadow-2xl focus:outline-none"
+        className="w-full max-w-md rounded-card bg-forge-iron border border-forge-steel p-8 shadow-2xl focus:outline-none"
         onClick={(e) => e.stopPropagation()}
       >
         <h2 id={titleId} className="sr-only">

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession, signOut } from "next-auth/react";
+import { ForgeMark } from "@/components/layout/ForgeMark";
 
 const mainNavItems = [
   {
@@ -37,11 +38,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const sidebarContent = (
     <>
       {/* Logo */}
-      <div className="flex items-center gap-2.5 px-4 py-5 border-b border-gray-800">
-        <div className="h-8 w-8 rounded bg-blue-600 flex items-center justify-center text-white font-bold text-sm">
-          PF
-        </div>
-        <span className="font-semibold text-gray-100 tracking-tight">project-forge</span>
+      <div className="flex items-center gap-2.5 px-4 py-5 border-b border-forge-steel">
+        <ForgeMark className="h-6 w-6" />
+        <span className="font-display font-semibold text-forge-mist tracking-tight">project-forge</span>
       </div>
 
       {/* Navigation */}
@@ -51,10 +50,10 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             key={item.href}
             href={item.href}
             onClick={() => setSidebarOpen(false)}
-            className={`flex items-center gap-3 rounded px-3 py-2.5 text-sm font-medium transition-colors ${
+            className={`flex items-center gap-3 rounded-btn px-3 py-2.5 text-sm font-medium transition-colors ${
               isActive(item.href)
-                ? "bg-gray-800 text-white"
-                : "text-gray-400 hover:bg-gray-800/50 hover:text-gray-200"
+                ? "bg-forge-steel text-forge-mist"
+                : "text-forge-ash hover:bg-forge-steel/60 hover:text-forge-mist"
             }`}
           >
             {item.icon}
@@ -66,10 +65,10 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         <Link
           href="/create"
           onClick={() => setSidebarOpen(false)}
-          className={`flex items-center gap-3 rounded px-3 py-2.5 text-sm font-medium transition-colors mt-3 ${
+          className={`flex items-center gap-3 rounded-btn px-3 py-2.5 text-sm font-medium transition-colors mt-3 ${
             isActive("/create")
-              ? "bg-blue-600 text-white"
-              : "bg-blue-600/10 text-blue-400 hover:bg-blue-600/20 hover:text-blue-300"
+              ? "bg-ember text-forge-void"
+              : "bg-ember/10 text-ember hover:bg-ember/20 hover:text-ember-soft"
           }`}
         >
           <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
@@ -81,21 +80,21 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
       {/* User menu (collapsible) */}
       {session?.user && (
-        <div className="border-t border-gray-800 px-3 py-3">
+        <div className="border-t border-forge-steel px-3 py-3">
           <button
             onClick={() => setUserMenuOpen((o) => !o)}
-            className="flex items-center gap-3 w-full rounded px-3 py-2.5 text-left hover:bg-gray-800/50 transition-colors"
+            className="flex items-center gap-3 w-full rounded-btn px-3 py-2.5 text-left hover:bg-forge-steel/60 transition-colors"
           >
-            <div className="h-8 w-8 rounded-full bg-gray-700 flex items-center justify-center text-xs font-medium text-gray-300 shrink-0">
+            <div className="h-8 w-8 rounded-full bg-forge-steel flex items-center justify-center text-xs font-medium text-forge-ash shrink-0">
               {session.user.email?.charAt(0).toUpperCase() ?? "U"}
             </div>
             <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-gray-200 truncate">
+              <p className="text-sm font-medium text-forge-mist truncate">
                 {session.user.email}
               </p>
             </div>
             <svg
-              className={`w-4 h-4 text-gray-500 transition-transform ${userMenuOpen ? "rotate-180" : ""}`}
+              className={`w-4 h-4 text-forge-ash transition-transform ${userMenuOpen ? "rotate-180" : ""}`}
               fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"
             >
               <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
@@ -107,10 +106,10 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               <Link
                 href="/settings"
                 onClick={() => { setSidebarOpen(false); setUserMenuOpen(false); }}
-                className={`flex items-center gap-3 rounded px-3 py-2 text-sm transition-colors ${
+                className={`flex items-center gap-3 rounded-btn px-3 py-2 text-sm transition-colors ${
                   isActive("/settings")
-                    ? "bg-gray-800 text-white"
-                    : "text-gray-400 hover:bg-gray-800/50 hover:text-gray-200"
+                    ? "bg-forge-steel text-forge-mist"
+                    : "text-forge-ash hover:bg-forge-steel/60 hover:text-forge-mist"
                 }`}
               >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
@@ -121,7 +120,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               </Link>
               <button
                 onClick={() => signOut({ callbackUrl: "/" })}
-                className="flex items-center gap-3 w-full rounded px-3 py-2 text-sm text-gray-400 hover:bg-gray-800/50 hover:text-gray-200 transition-colors"
+                className="flex items-center gap-3 w-full rounded-btn px-3 py-2 text-sm text-forge-ash hover:bg-forge-steel/60 hover:text-forge-mist transition-colors"
               >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3 0l3-3m0 0l-3-3m3 3H9" />
@@ -136,33 +135,31 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <div className="min-h-screen bg-gray-950 text-gray-100">
+    <div className="min-h-screen bg-forge-void text-forge-mist">
       {/* Mobile top bar */}
-      <div className="md:hidden fixed top-0 left-0 right-0 z-40 flex items-center gap-3 border-b border-gray-800 bg-gray-950/95 backdrop-blur-sm px-4 py-3">
+      <div className="md:hidden fixed top-0 left-0 right-0 z-40 flex items-center gap-3 border-b border-forge-steel bg-forge-void/95 backdrop-blur-sm px-4 py-3">
         <button
           onClick={() => setSidebarOpen(true)}
-          className="rounded p-1.5 text-gray-400 hover:bg-gray-800 hover:text-gray-200 transition"
+          className="rounded-btn p-1.5 text-forge-ash hover:bg-forge-steel hover:text-forge-mist transition"
         >
           <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
           </svg>
         </button>
         <div className="flex items-center gap-2">
-          <div className="h-6 w-6 rounded bg-blue-600 flex items-center justify-center text-white font-bold text-xs">
-            PF
-          </div>
-          <span className="font-semibold text-sm">project-forge</span>
+          <ForgeMark className="h-5 w-5" />
+          <span className="font-display font-semibold text-sm text-forge-mist">project-forge</span>
         </div>
       </div>
 
       {/* Mobile sidebar overlay */}
       {sidebarOpen && (
         <div
-          className="md:hidden fixed inset-0 z-50 bg-black/60 backdrop-blur-sm"
+          className="md:hidden fixed inset-0 z-50 bg-forge-void/60 backdrop-blur-sm"
           onClick={() => setSidebarOpen(false)}
         >
           <aside
-            className="h-full w-64 bg-gray-900 border-r border-gray-800 flex flex-col"
+            className="h-full w-64 bg-forge-iron border-r border-forge-steel flex flex-col"
             onClick={(e) => e.stopPropagation()}
           >
             {sidebarContent}
@@ -171,7 +168,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       )}
 
       {/* Desktop sidebar */}
-      <aside className="hidden md:flex md:fixed md:inset-y-0 md:left-0 md:w-56 md:flex-col md:border-r md:border-gray-800 md:bg-gray-900">
+      <aside className="hidden md:flex md:fixed md:inset-y-0 md:left-0 md:w-56 md:flex-col md:border-r md:border-forge-steel md:bg-forge-iron">
         {sidebarContent}
       </aside>
 

--- a/components/layout/ForgeMark.tsx
+++ b/components/layout/ForgeMark.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useId } from "react";
+
+interface ForgeMarkProps {
+  className?: string;
+}
+
+/**
+ * Minimal Forge brand mark — an ember-to-gold flame/spark glyph.
+ * Used in PublicNav and AppShell.
+ */
+export function ForgeMark({ className = "h-5 w-5" }: ForgeMarkProps) {
+  const uid = useId();
+  // useId returns strings like ":r0:", clean to a valid SVG id (must start with letter)
+  const gradId = `fm${uid.replace(/[^a-zA-Z0-9]/g, "")}`;
+
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient
+          id={gradId}
+          x1="10"
+          y1="18"
+          x2="11"
+          y2="1"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0%" stopColor="#F5641E" />
+          <stop offset="100%" stopColor="#FFB02E" />
+        </linearGradient>
+      </defs>
+      {/* Outer flame — ember to gold */}
+      <path
+        d="M10 1.5C7.5 7 5 8 6.5 12.5C7.5 15.5 10 16.5 10 16.5C10 16.5 12.5 15.5 13.5 12.5C15 8 12.5 7 10 1.5Z"
+        fill={`url(#${gradId})`}
+      />
+      {/* Inner highlight — hot core */}
+      <path
+        d="M10 12C9.4 10.5 9.2 9 10 8C10.8 9 10.6 10.5 10 12Z"
+        fill="#FFB02E"
+        fillOpacity="0.45"
+      />
+    </svg>
+  );
+}

--- a/components/layout/PublicNav.tsx
+++ b/components/layout/PublicNav.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useSession } from "next-auth/react";
+import { usePathname } from "next/navigation";
 import { ForgeMark } from "@/components/layout/ForgeMark";
 
 /**
@@ -14,6 +15,7 @@ import { ForgeMark } from "@/components/layout/ForgeMark";
 export function PublicNav() {
   const { status } = useSession();
   const isAuthed = status === "authenticated";
+  const onLoginPage = usePathname() === "/login";
 
   return (
     <nav className="sticky top-0 z-30 border-b border-forge-steel bg-forge-void/95 backdrop-blur-sm px-6 py-4">
@@ -21,7 +23,7 @@ export function PublicNav() {
         {/* Logo */}
         <Link href="/" className="flex items-center gap-2.5 group">
           <ForgeMark className="h-6 w-6" />
-          <span className="font-display font-semibold text-lg text-forge-mist tracking-tight group-hover:text-white transition-colors">
+          <span className="font-display font-semibold text-lg text-forge-mist tracking-tight group-hover:text-gold transition-colors">
             project-forge
           </span>
         </Link>
@@ -43,20 +45,22 @@ export function PublicNav() {
               Dashboard
             </Link>
           ) : (
-            <>
-              <Link
-                href="/login"
-                className="text-forge-ash hover:text-forge-mist transition-colors"
-              >
-                Login
-              </Link>
-              <Link
-                href="/login"
-                className="rounded-btn bg-ember px-4 py-2 text-forge-void font-medium hover:bg-ember-soft transition-colors"
-              >
-                Get Started
-              </Link>
-            </>
+            !onLoginPage && (
+              <>
+                <Link
+                  href="/login"
+                  className="text-forge-ash hover:text-forge-mist transition-colors"
+                >
+                  Login
+                </Link>
+                <Link
+                  href="/login"
+                  className="rounded-btn bg-ember px-4 py-2 text-forge-void font-medium hover:bg-ember-soft transition-colors"
+                >
+                  Get Started
+                </Link>
+              </>
+            )
           )}
         </div>
       </div>

--- a/components/layout/PublicNav.tsx
+++ b/components/layout/PublicNav.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+import { ForgeMark } from "@/components/layout/ForgeMark";
+
+/**
+ * Shared top-nav for all public pages (landing, login, public docs).
+ *
+ * Session-aware:
+ *  - Unauthenticated: shows "Login" text link + "Get Started" primary button
+ *  - Authenticated:   shows "Dashboard" primary button (user is likely redirecting away anyway)
+ */
+export function PublicNav() {
+  const { status } = useSession();
+  const isAuthed = status === "authenticated";
+
+  return (
+    <nav className="sticky top-0 z-30 border-b border-forge-steel bg-forge-void/95 backdrop-blur-sm px-6 py-4">
+      <div className="flex items-center justify-between max-w-7xl mx-auto">
+        {/* Logo */}
+        <Link href="/" className="flex items-center gap-2.5 group">
+          <ForgeMark className="h-6 w-6" />
+          <span className="font-display font-semibold text-lg text-forge-mist tracking-tight group-hover:text-white transition-colors">
+            project-forge
+          </span>
+        </Link>
+
+        {/* Right-side links */}
+        <div className="flex items-center gap-5 text-sm">
+          <Link
+            href="/docs"
+            className="text-forge-ash hover:text-forge-mist transition-colors"
+          >
+            Docs
+          </Link>
+
+          {isAuthed ? (
+            <Link
+              href="/dashboard"
+              className="rounded-btn bg-ember px-4 py-2 text-forge-void font-medium hover:bg-ember-soft transition-colors"
+            >
+              Dashboard
+            </Link>
+          ) : (
+            <>
+              <Link
+                href="/login"
+                className="text-forge-ash hover:text-forge-mist transition-colors"
+              >
+                Login
+              </Link>
+              <Link
+                href="/login"
+                className="rounded-btn bg-ember px-4 py-2 text-forge-void font-medium hover:bg-ember-soft transition-colors"
+              >
+                Get Started
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/components/ui/PageShell.tsx
+++ b/components/ui/PageShell.tsx
@@ -28,9 +28,9 @@ export function PageShell({
         {/* Header */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
           <div>
-            <h1 className="text-2xl sm:text-3xl font-bold text-gray-100">{title}</h1>
+            <h1 className="text-2xl sm:text-3xl font-bold text-forge-mist">{title}</h1>
             {subtitle && (
-              <p className="text-gray-400 mt-1 text-sm sm:text-base">{subtitle}</p>
+              <p className="text-forge-ash mt-1 text-sm sm:text-base">{subtitle}</p>
             )}
           </div>
           {actions && <div className="flex items-center gap-3">{actions}</div>}


### PR DESCRIPTION
## T-002: Forge shared chrome

Part of the project-forge UI overhaul (run 2026-06-19). Builds on the merged Forge foundation (T-001).

**What:**
- New session-aware PublicNav + ForgeMark brand SVG (ember to gold flame), swapped into the landing, login, and public-docs nav regions (dedupes 3 inline navs).
- AppShell, PageShell, DialogShell retoned to Forge tokens. DialogShell behavior (focus-trap, Escape, aria-modal, scroll-lock, focus-return, initialFocusRef) is byte-for-byte preserved; only colors and radii changed.
- Forge favicon: public/favicon.svg + app/icon.svg (single source via the file convention).

**Scope:** page bodies, auth, API, and the create-wizard state machine are untouched; AppShell stays applied per-page (no route-group layout, so the public login page stays sidebar-free).

**Verification:** npm run build clean; 105/105 tests pass.

**Review:** reviewer subagent returned accept_with_notes; DialogShell color-only confirmed. Fixed inline: self-referential login CTA suppressed on /login, logo hover moved to a forge token, favicon source de-duplicated.

**Known follow-ups (by design, owned by later tasks):** ConfirmModal/ErrorModal bodies + settings spinner stay old-styled until T-006c/T-007. Visual verification is pending (WSL headless CSS does not render in this env; DOM + build verified).

Refs: project-forge UI overhaul (Forge), task T-002
