### PR TITLE
feat(ui): Forge create wizard + modals (T-006c)

### DIFF
--- a/app/(dashboard)/create/page.tsx
+++ b/app/(dashboard)/create/page.tsx
@@ -26,7 +26,7 @@ function CopyButton({ text }: { text: string }) {
     <button
       type="button"
       aria-label="Copy to clipboard"
-      className="ml-2 text-gray-500 hover:text-gray-300 transition shrink-0"
+      className="ml-2 text-forge-ash hover:text-forge-mist transition shrink-0"
       onClick={() => {
         navigator.clipboard.writeText(text);
         setCopied(true);
@@ -34,7 +34,7 @@ function CopyButton({ text }: { text: string }) {
       }}
     >
       {copied ? (
-        <svg className="w-4 h-4 text-green-400" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <svg className="w-4 h-4 text-success" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
         </svg>
       ) : (
@@ -47,7 +47,7 @@ function CopyButton({ text }: { text: string }) {
 }
 
 export default function CreatePage() {
-  const { data: session, status } = useSession();
+  const { status } = useSession();
   const router = useRouter();
   const [state, setState] = useState<State>("form");
   const [preview, setPreview] = useState<GenerationPreview | null>(null);
@@ -133,14 +133,14 @@ export default function CreatePage() {
             {needsGithub && (
               <Card tone="warning" padding="md" className="mb-6">
                 <div className="flex items-start gap-3">
-                  <div className="h-10 w-10 rounded-md bg-yellow-600/20 flex items-center justify-center text-yellow-400 shrink-0">
+                  <div className="h-10 w-10 rounded-btn bg-warning/20 flex items-center justify-center text-warning shrink-0">
                     <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
                     </svg>
                   </div>
                   <div className="flex-1">
-                    <h3 className="font-semibold text-yellow-200 mb-1">GitHub connection required</h3>
-                    <p className="text-sm text-gray-400 mb-4">
+                    <h3 className="font-semibold text-gold mb-1">GitHub connection required</h3>
+                    <p className="text-sm text-forge-ash mb-4">
                       Connect your GitHub account to create repositories. Choose OAuth for the fastest setup.
                     </p>
                     <div className="flex flex-col sm:flex-row gap-2">
@@ -196,23 +196,23 @@ export default function CreatePage() {
         {state === "publishing" && (
           <Card padding="lg" className="text-center">
             <div className="py-8">
-              <div className="h-10 w-10 animate-spin rounded-full border-2 border-blue-500 border-t-transparent mx-auto mb-4" />
-              <p className="text-gray-300 font-medium">Creating repository...</p>
-              <p className="text-gray-500 text-sm mt-1">This may take a moment.</p>
+              <div className="h-10 w-10 animate-spin rounded-full border-2 border-ember border-t-transparent mx-auto mb-4" />
+              <p className="text-forge-mist font-medium">Creating repository...</p>
+              <p className="text-forge-ash text-sm mt-1">This may take a moment.</p>
             </div>
           </Card>
         )}
 
         {state === "done" && repoUrl && (
           <Card tone="success" padding="lg" className="text-center">
-            <div className="h-12 w-12 rounded-full bg-green-600/20 flex items-center justify-center mx-auto mb-4">
-              <svg className="w-6 h-6 text-green-400" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <div className="h-12 w-12 rounded-full bg-success/20 flex items-center justify-center mx-auto mb-4">
+              <svg className="w-6 h-6 text-success" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
               </svg>
             </div>
-            <h2 className="text-2xl font-semibold mb-2">Project Created!</h2>
-            <div className="flex items-center rounded-md bg-gray-900 px-4 py-3 mb-6">
-              <code className="text-sm text-green-400 font-mono flex-1 overflow-x-auto">
+            <h2 className="font-display text-2xl font-semibold text-forge-mist mb-2">Project Created!</h2>
+            <div className="flex items-center rounded-card bg-forge-iron px-4 py-3 mb-6">
+              <code className="text-sm text-forge-mist font-mono flex-1 overflow-x-auto">
                 git clone {repoUrl}
               </code>
               <CopyButton text={`git clone ${repoUrl}`} />

--- a/components/ConfirmModal.tsx
+++ b/components/ConfirmModal.tsx
@@ -29,33 +29,33 @@ export function ConfirmModal({
     >
       <>
         <div className="text-center mb-6">
-          <div className="h-12 w-12 rounded-md bg-green-600/20 flex items-center justify-center mx-auto mb-4">
-            <svg className="w-6 h-6 text-green-400" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+          <div className="h-12 w-12 rounded-btn bg-success/20 flex items-center justify-center mx-auto mb-4">
+            <svg className="w-6 h-6 text-success" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" d="M15.59 14.37a6 6 0 01-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 006.16-12.12A14.98 14.98 0 009.631 8.41m5.96 5.96a14.926 14.926 0 01-5.841 2.58m-.119-8.54a6 6 0 00-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 00-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 01-2.448-2.448 14.9 14.9 0 01.06-.312m-2.24 2.39a4.493 4.493 0 00-1.757 4.306 4.493 4.493 0 004.306-1.758M16.5 9a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z" />
             </svg>
           </div>
-          <h2 className="text-xl font-semibold text-white">Create GitHub Repository?</h2>
-          <p className="text-gray-400 text-sm mt-2">
+          <h2 className="text-xl font-semibold text-forge-mist">Create GitHub Repository?</h2>
+          <p className="text-forge-ash text-sm mt-2">
             This will create a public repository and push the scaffold.
           </p>
         </div>
 
-        <div className="rounded-md bg-gray-800 p-4 mb-6 space-y-2.5 text-sm">
+        <div className="rounded-card bg-forge-steel p-4 mb-6 space-y-2.5 text-sm">
           <div className="flex justify-between">
-            <span className="text-gray-400">Repository</span>
-            <span className="text-gray-100 font-mono">{projectName}</span>
+            <span className="text-forge-ash">Repository</span>
+            <span className="text-forge-mist font-mono">{projectName}</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-gray-400">Tasks</span>
-            <span className="text-gray-100">{taskCount} tasks</span>
+            <span className="text-forge-ash">Tasks</span>
+            <span className="text-forge-mist">{taskCount} tasks</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-gray-400">Waves</span>
-            <span className="text-gray-100">{waveCount} waves</span>
+            <span className="text-forge-ash">Waves</span>
+            <span className="text-forge-mist">{waveCount} waves</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-gray-400">Visibility</span>
-            <span className="text-green-400">Public</span>
+            <span className="text-forge-ash">Visibility</span>
+            <span className="text-success">Public</span>
           </div>
         </div>
 

--- a/components/ErrorModal.tsx
+++ b/components/ErrorModal.tsx
@@ -25,13 +25,13 @@ export function ErrorModal({
     >
       <>
         <div className="text-center mb-6">
-          <div className="h-12 w-12 rounded-md bg-red-600/20 flex items-center justify-center mx-auto mb-4">
-            <svg className="w-6 h-6 text-red-400" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+          <div className="h-12 w-12 rounded-btn bg-danger/20 flex items-center justify-center mx-auto mb-4">
+            <svg className="w-6 h-6 text-danger" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9.303 3.376c.866 1.5-.217 3.374-1.948 3.374H4.645c-1.73 0-2.813-1.874-1.948-3.374L10.051 3.378c.866-1.5 3.032-1.5 3.898 0l7.354 12.748zM12 15.75h.007v.008H12v-.008z" />
             </svg>
           </div>
-          <h2 className="text-xl font-semibold text-white">{title}</h2>
-          <p className="text-gray-400 text-sm mt-3">
+          <h2 className="text-xl font-semibold text-forge-mist">{title}</h2>
+          <p className="text-forge-ash text-sm mt-3">
             {message}
           </p>
         </div>


### PR DESCRIPTION
## T-006c: Forge create wizard + Confirm/Error modals

Part of the project-forge UI overhaul (run 2026-06-19). Builds on T-001 + T-002.

Restyle the create wizard chrome (app/(dashboard)/create/page.tsx) and the ConfirmModal/ErrorModal bodies to Forge: CopyButton, the github-gate card, publishing spinner to ember, the done-state git-clone block in font-mono on forge-iron, and the modal icon chips/stat blocks to success/danger/warning semantic tokens. Also removed a pre-existing unused `session` binding (lint warning).

Behavior verbatim (class-only diff): the full state machine (form -> loading -> preview -> confirming -> publishing -> done), /api/generate + /api/publish (request shapes, headers, error handling), the githubConnected disabled-overlay (opacity-40 + inert + aria-hidden), CopyButton 2s reset, the done-state reset, and the modals' DialogShell usage + initialFocusRef. DialogShell.tsx not touched.

Verification: npm run build clean; 105/105 tests; no legacy literals. Reviewer accept_with_notes; state machine + API calls + setters confirmed byte-identical; tokens confirmed to resolve. Visual verification deferred (authed /create not capturable headless) — recommend an eyeball pass before deploy.

Refs: project-forge UI overhaul (Forge), task T-006c
