### PR TITLE
feat(ui): Forge docs + SwaggerUI theme (T-008)

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -21,17 +21,17 @@ function DocsContent() {
         <CardHeader title="Quick Start" />
         <div className="space-y-5 text-sm">
           <div>
-            <h3 className="font-semibold text-gray-200 mb-2">1. Get an API Token</h3>
-            <p className="text-gray-400">
+            <h3 className="font-semibold text-forge-mist mb-2">1. Get an API Token</h3>
+            <p className="text-forge-ash">
               Sign up at{" "}
-              <a href="/login" className="text-blue-400 hover:text-blue-300 transition">/login</a>,
+              <a href="/login" className="text-ember hover:text-ember-soft transition">/login</a>,
               configure your GitHub PAT, and create an API token in your{" "}
-              <a href="/dashboard" className="text-blue-400 hover:text-blue-300 transition">dashboard</a>.
+              <a href="/dashboard" className="text-ember hover:text-ember-soft transition">dashboard</a>.
             </p>
           </div>
           <div>
-            <h3 className="font-semibold text-gray-200 mb-2">2. Make a Request</h3>
-            <pre className="rounded-md bg-gray-800 px-4 py-3 font-mono text-gray-300 overflow-x-auto">
+            <h3 className="font-semibold text-forge-mist mb-2">2. Make a Request</h3>
+            <pre className="rounded-card bg-forge-iron px-4 py-3 font-mono text-forge-mist overflow-x-auto">
 {`curl -X POST https://project-forge.opentriologue.ai/api/v1/projects \\
   -H "Content-Type: application/json" \\
   -H "X-API-Key: pf_your_token_here" \\
@@ -44,11 +44,11 @@ function DocsContent() {
             </pre>
           </div>
           <div>
-            <h3 className="font-semibold text-gray-200 mb-2">3. Clone &amp; Develop</h3>
-            <p className="text-gray-400 mb-2">
+            <h3 className="font-semibold text-forge-mist mb-2">3. Clone &amp; Develop</h3>
+            <p className="text-forge-ash mb-2">
               The API returns a GitHub repository URL. Clone it and start developing:
             </p>
-            <pre className="rounded-md bg-gray-800 px-4 py-3 font-mono text-gray-300">
+            <pre className="rounded-card bg-forge-iron px-4 py-3 font-mono text-forge-mist">
               git clone https://github.com/username/my-app.git
             </pre>
           </div>
@@ -78,14 +78,14 @@ export default function ApiDocsPage() {
 
   // Public view — standalone layout without sidebar
   return (
-    <main className="min-h-screen bg-gray-950 text-gray-100">
+    <main className="min-h-screen bg-forge-void text-forge-mist">
       <PublicNav />
 
       <div className="px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
         <div className="mx-auto max-w-7xl">
           <div className="mb-8">
             <h1 className="text-2xl sm:text-3xl font-bold">API Documentation</h1>
-            <p className="text-gray-400 mt-1 text-sm sm:text-base">Interactive API reference for project-forge</p>
+            <p className="text-forge-ash mt-1 text-sm sm:text-base">Interactive API reference for project-forge</p>
           </div>
           <DocsContent />
         </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -60,12 +60,12 @@
 
 /* ── Swagger UI dark-mode overrides ── */
 .swagger-ui {
-  --bg: #0a0a0f;
-  --bg-secondary: #111118;
-  --border: #1e1e2e;
-  --text: #e2e2e8;
-  --text-muted: #9393a8;
-  --accent: #3b82f6;
+  --bg: #0B0D10;
+  --bg-secondary: #14181D;
+  --border: #222A32;
+  --text: #E7ECF2;
+  --text-muted: #8A93A0;
+  --accent: #F5641E;
 }
 
 .swagger-ui,


### PR DESCRIPTION
## T-008: Forge docs page + SwaggerUI theme

Part of the project-forge UI overhaul (run 2026-06-19). Builds on T-001 + T-002.

Re-point the `.swagger-ui` CSS-override variables in app/globals.css to the Forge palette (bg→void, bg-secondary→iron, border→steel, text→mist, text-muted→ash, accent→ember), keeping the `!important` override mechanism intact (Swagger is not Tailwind-ized). The Forge `:root` token block (T-001) is untouched. Retone app/docs/page.tsx chrome: forge-void main, font-mono forge-iron code blocks, ember links.

Behavior verbatim: SwaggerUI dynamic import (ssr:false, url=/openapi.json), the session-gated AppShell-vs-standalone layout, and the shared PublicNav. Only the two listed files changed.

Verification: npm run build clean; 105/105 tests; no old-palette hexes (#3b82f6/#0a0a0f/...) and no blue-/gray- literals remain; orchestrator self-reviewed the globals.css diff (only the swagger var block changed). Visual deferred (swagger-ui screenshot not captured this run).

Refs: project-forge UI overhaul (Forge), task T-008
