### PR TITLE
feat(ui): Forge polish + a11y (T-009)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -35,6 +35,18 @@
   }
 }
 
+/* ── Reduced motion: honor the OS/user preference (a11y) ── */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* ── Heat utilities ── */
 
 /* Full heat gradient — apply as background */

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -261,12 +261,11 @@ export function ProjectForm({ onSubmit, isLoading = false, initialValues }: Proj
               />
               <Button
                 type="button"
-                variant="primary"
+                variant="gold"
                 size="sm"
                 onClick={handleMagicFill}
                 disabled={!magicPrompt.trim() || isLoading}
                 loading={magicLoading}
-                className="bg-gold hover:bg-gold/90 text-forge-void"
               >
                 Fill Form
               </Button>
@@ -321,18 +320,18 @@ export function ProjectForm({ onSubmit, isLoading = false, initialValues }: Proj
                 </p>
                 <Button
                   type="button"
-                  variant="primary"
+                  variant="gold"
                   size="sm"
                   onClick={handleMagicFill}
                   disabled={!attachment || isLoading}
                   loading={magicLoading}
-                  className="bg-gold hover:bg-gold/90 text-forge-void shrink-0"
+                  className="shrink-0"
                 >
                   Fill Form
                 </Button>
               </div>
               {attachmentError && (
-                <p className="text-xs text-red-400" role="alert">
+                <p className="text-xs text-danger" role="alert">
                   {attachmentError}
                 </p>
               )}

--- a/components/ui/primitives/Button.tsx
+++ b/components/ui/primitives/Button.tsx
@@ -1,6 +1,6 @@
 import { ButtonHTMLAttributes, forwardRef } from "react";
 
-type Variant = "primary" | "secondary" | "danger" | "ghost" | "success";
+type Variant = "primary" | "secondary" | "danger" | "ghost" | "success" | "gold";
 type Size = "sm" | "md" | "lg";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -10,7 +10,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   loading?: boolean;
 }
 
-// WCAG AA note: ember primary uses text-forge-void (#0B0D10 on #F5641E = 6.14:1 contrast)
+// WCAG AA note: ember primary = text-forge-void on #F5641E (6.14:1); gold = text-forge-void on #FFB02E (~10.7:1, AAA)
 const variantStyles: Record<Variant, string> = {
   primary:
     "bg-ember text-forge-void hover:bg-ember-soft focus-visible:ring-ember",
@@ -22,6 +22,9 @@ const variantStyles: Record<Variant, string> = {
     "text-forge-ash hover:text-forge-mist hover:bg-forge-steel/60 focus-visible:ring-forge-ash",
   success:
     "bg-success/15 text-success hover:bg-success/25 focus-visible:ring-success",
+  // gold = the "AI / creative spark" accent (forge heat-peak), distinct from the ember primary action
+  gold:
+    "bg-gold text-forge-void hover:bg-gold/90 focus-visible:ring-gold",
 };
 
 const sizeStyles: Record<Size, string> = {


### PR DESCRIPTION
## T-009: Forge polish & a11y

Final pass of the project-forge UI overhaul (run 2026-06-19). Builds on T-001..T-008.

- **gold Button variant**: adds a dedicated `variant="gold"` (bg-gold, text-forge-void, hover bg-gold/90, focus-visible ring-gold) and switches the ProjectForm Magic-Fill buttons to it, removing the prior `variant="primary"` + `bg-gold` className override that relied on CSS source order (closes the T-006a follow-up). Gold buttons now get a gold focus ring instead of ember. Contrast text-forge-void on #FFB02E is ~10.7:1 (AAA).
- **leftover literal**: a stray `text-red-400` in ProjectForm's attachment-error became `text-danger`.
- **reduced motion**: globals.css gains a `@media (prefers-reduced-motion: reduce)` safety net that neutralizes transitions/animations when the user opts out (no effect on default rendering). Motion is intentionally restrained beyond this; no orchestrated animation was added.

A repo-wide sweep confirms zero off-palette literals remain in app/ + components/ (the /styleguide swatches keep hex values by design).

Verification: npm run build clean; 105/105 tests; reviewer accept; scope is exactly Button.tsx, ProjectForm.tsx, globals.css.

Refs: project-forge UI overhaul (Forge), task T-009
