### PR TITLE
fix(deps): bump transitive dompurify to 3.4.11 (GHSA-cmwh-pvxp-8882)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4252,9 +4252,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
## What
Bumps the transitive `dompurify` dependency from 3.4.10 to 3.4.11 (lockfile only) to resolve GHSA-cmwh-pvxp-8882 (moderate): permanent ALLOWED_ATTR pollution via setConfig() bypassing the hook clone-guard. dompurify is pulled in transitively via swagger-ui-react.

## Verification
- `npm audit --package-lock-only`: 1 moderate, then 0 vulnerabilities after the bump
- `tsc --noEmit`: clean
- Diff is 3 lines, only the dompurify lockfile entry (version, resolved, integrity); nothing else re-resolved

## Notes
Part of the org-wide CVE sweep 2026-06-21. dompurify stays transitive via swagger-ui-react, so a future swagger-ui-react that pins dompurify below 3.4.11 could regress this on a fresh install.

Refs: CVE sweep 2026-06-21