### PR TITLE
chore(release): project-forge v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-25
+
+Forge gains a first-class web UI: a complete Next.js front-end — a landing page, authentication, dashboard, a guided project-create wizard with live preview, settings, and themed API docs — built on a new gold-accented design system. A transitive dompurify advisory and the 2026-06-16 CVE sweep are also cleared.
+
+### Added
+
+- **Forge design foundation and app chrome** (PRs #88, #89; tasks T-001/T-002): a new gold-accented design system and the shared application chrome (navigation, layout shell) that the rest of the UI builds on.
+- **Forge web pages** (PRs #90, #91, #92, #96, #97; tasks T-003/T-004/T-005/T-007/T-008): a landing page, login, dashboard, settings, and a docs page with a themed SwaggerUI.
+- **Guided project-create wizard** (PRs #93, #94, #95; tasks T-006a/b/c): a `ProjectForm` with a Magic-Fill gold accent, a live `PreviewPanel`, and a multi-step create wizard with Confirm/Error modals.
+- **UI polish** (PR #98; task T-009): a gold `Button` variant and `prefers-reduced-motion` accessibility support.
+
+### Security
+
+- **dompurify bumped to ≥3.4.11** (PR #99): a transitive advisory in the dependency tree was cleared.
+- **CVE sweep 2026-06-16** (PR #86): vite and js-yaml advisories cleared across the lockfile.
+
+### Docs
+
+- **README/docs reconciled with code** (PR #87): drift between the documentation and the implementation was fixed.
+
 ## [0.5.0] - 2026-06-01
 
 ### Added

--- a/app/styleguide/page.tsx
+++ b/app/styleguide/page.tsx
@@ -293,7 +293,7 @@ export default function StyleguidePage() {
                 <span aria-hidden>★</span> Beta
               </Badge>
               <Badge variant="default">
-                v0.5.0
+                v0.6.0
               </Badge>
             </div>
           </SubSection>
@@ -407,7 +407,7 @@ export default function StyleguidePage() {
 
         {/* Footer */}
         <footer className="mt-8 pt-6 border-t border-forge-steel text-xs text-forge-ash text-center">
-          Forge design system — project-forge v0.5.0 — dark-only
+          Forge design system — project-forge v0.6.0 — dark-only
         </footer>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-forge",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Release v0.6.0

Forge gains a first-class web UI: a complete Next.js front-end (landing, auth, dashboard, a guided create wizard with live preview, settings, themed API docs) on a new gold-accented design system, plus a transitive dompurify CVE fix and the 2026-06-16 CVE sweep. 14 commits since v0.5.0 (#86-#99).

### Highlights

- **Forge web UI (tasks T-001..T-009):** the design foundation and app chrome (#88, #89), the landing/login/dashboard/settings/docs pages (#90-#92, #96, #97), a guided `ProjectForm` + live `PreviewPanel` + create wizard with Confirm/Error modals (#93-#95), and polish: a gold `Button` variant and `prefers-reduced-motion` support (#98).
- **Security:** dompurify bumped to >=3.4.11 (#99), and a vite + js-yaml CVE sweep (#86).
- **Docs:** README/docs drift reconciled with the code (#87).

### Test plan

- [x] `prisma generate`, `tsc --noEmit --skipLibCheck`, `eslint .` (0 errors, 1 pre-existing warning), `next build`, `vitest run` (11 files, 105 passing)
- [x] Live smoke vs `https://project-forge.opentriologue.ai`: public routes `/`, `/login`, `/docs`, `/styleguide` returned 200; protected `/dashboard`, `/create`, `/settings` returned 307 (auth redirect); `/api/v1/projects` and `/api/v1/preview` returned 401 (auth-gated)
- [ ] CI green on this PR

Note: the `package-lock.json` root version is intentionally left at 0.5.0, matching the v0.5.0 release commit; `npm ci` validates the dependency tree, not the root version field.

Refs: project-forge v0.6.0 web-UI milestone
