### PR TITLE
chore: gitignore docker-compose.override.yml so VPS deploys skip --force

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ db/
 
 # orchestrator-workflow run state (local only)
 .ai/
+
+# VPS-side deployment override: prod secrets + named volumes. Must stay
+# untracked on the host (never committed); gitignored so deploy-panel's
+# git_clean preflight passes without --force.
+docker-compose.override.yml
+docker-compose.override.yml.bak-*


### PR DESCRIPTION
## What

The VPS-side `docker-compose.override.yml` (prod secrets + `forge_db` volume) is untracked and not gitignored, so deploy-panel's `git_clean` preflight always reports the tree dirty and the deploy must run with `force: true`. This ignores the override file and its `.bak-*` siblings so the preflight passes cleanly.

## Verification

- `git check-ignore --no-index docker-compose.override.yml` → matches ✅
- `git check-ignore --no-index docker-compose.override.yml.bak-2026-04-04-pr30` → matches ✅
- `docker-compose.yml` and `docker-compose.prod.yml` are **not** ignored ✅ (tracked compose files unaffected)
- Diff is `.gitignore`-only, additive, no secret committed.

Scope: `.gitignore` only. No runtime/compose/deploy-config changes.

Refs: task 1f72112b