### PR TITLE
feat(styleguide): source version from package.json (single source of truth)

### DIFF
--- a/app/styleguide/page.tsx
+++ b/app/styleguide/page.tsx
@@ -50,6 +50,9 @@ function Swatch({ name, hex, bg, textColor = "text-forge-mist" }: SwatchProps) {
 export default function StyleguidePage() {
   const [alertOpen, setAlertOpen] = useState(true);
   const [alertSuccessOpen, setAlertSuccessOpen] = useState(true);
+  // Sourced from package.json at build time via next.config.mjs (single
+  // source of truth); falls back to "dev" if the env var is ever unset.
+  const appVersion = process.env.NEXT_PUBLIC_APP_VERSION ?? "dev";
 
   return (
     <div className="min-h-screen bg-forge-void px-6 py-12">
@@ -65,6 +68,8 @@ export default function StyleguidePage() {
               Visual language reference for project-forge — dark-only, ember-accented.
             </p>
             <div className="mt-4 flex gap-2">
+              {/* Design-system version, intentionally a literal — distinct from
+                  the app version (appVersion) shown in the footer/sample badge. */}
               <Badge variant="info">v1.0</Badge>
               <Badge variant="default">dark-only</Badge>
             </div>
@@ -293,7 +298,7 @@ export default function StyleguidePage() {
                 <span aria-hidden>★</span> Beta
               </Badge>
               <Badge variant="default">
-                v0.6.0
+                v{appVersion}
               </Badge>
             </div>
           </SubSection>
@@ -407,7 +412,7 @@ export default function StyleguidePage() {
 
         {/* Footer */}
         <footer className="mt-8 pt-6 border-t border-forge-steel text-xs text-forge-ash text-center">
-          Forge design system — project-forge v0.6.0 — dark-only
+          Forge design system — project-forge v{appVersion} — dark-only
         </footer>
       </div>
     </div>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,18 @@
+import { readFileSync } from "node:fs";
+
+// Single source of truth for the app version surfaced in the UI (e.g. the
+// /styleguide footer). Read package.json at build time and expose only the
+// version string as a public env var, so the full package.json (incl.
+// devDependency names) never leaks into the client bundle.
+const { version } = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf-8"),
+);
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  env: {
+    NEXT_PUBLIC_APP_VERSION: version,
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## What

The `/styleguide` footer + a sample badge hard-coded the app version (`v0.6.0`), which drifted to `v0.5.0` against a `v0.6.0` tag last release and had to be bumped by hand (PR #100). This sources the version from `package.json` so a bump alone keeps the UI correct.

- `next.config.mjs`: read `package.json` at build time (Node) and expose only `NEXT_PUBLIC_APP_VERSION`.
- `app/styleguide/page.tsx`: `const appVersion = process.env.NEXT_PUBLIC_APP_VERSION ?? "dev"`, used in the footer and the sample badge.

## Why this approach

A direct `import pkg from "@/package.json"` in a `"use client"` component would pull the whole `package.json` (incl. devDependency names) into the client bundle. Reading it in `next.config.mjs` and exposing only the version string avoids that.

## Verification

- `next build` — green; styleguide client chunk **inlines** the version, and `grep .next/static` finds **no** devDependency names (no package.json leak).
- `tsc --noEmit` — green
- `eslint .` — 0 errors (1 pre-existing unrelated warning in `app/api/v1/projects/route.ts`)
- `vitest run` — 105/105 green

SSOT confirmed: footer/badge values now come from `package.json` `version` via the build-time env, with no literal in `page.tsx`.

Refs: task 0d0d8f2a