### PR TITLE
test(project-forge): cover dashboard GET + ai-provider + github + v1-shared (MED tail)

### DIFF
--- a/tests/integration/dashboard-route.test.ts
+++ b/tests/integration/dashboard-route.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * Integration tests for GET /api/dashboard.
+ *
+ * SECURITY NOTE (resolved, do not re-litigate): the route intentionally
+ * returns the caller's own `githubPat` in the response body — this is the
+ * owner viewing their own PAT, and the settings page relies on it. These
+ * tests assert that value is present, not scrub it.
+ */
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/db", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/db")>("@/lib/db");
+  return {
+    ...actual,
+    prisma: {
+      user: {
+        findUnique: vi.fn(),
+      },
+    },
+  };
+});
+
+import { getServerSession } from "next-auth";
+import { prisma } from "@/lib/db";
+import { GET } from "@/app/api/dashboard/route";
+
+const mGetSession = vi.mocked(getServerSession);
+
+const user = prisma.user as unknown as {
+  findUnique: ReturnType<typeof vi.fn>;
+};
+
+const AUTHED_SESSION = { user: { id: "user-1", email: "u@test.com" } };
+
+describe("GET /api/dashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("401 when there is no session", async () => {
+    mGetSession.mockResolvedValue(null);
+
+    const res = await GET();
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+    expect(user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("401 when session exists but has no user.id", async () => {
+    mGetSession.mockResolvedValue({ user: {} } as never);
+
+    const res = await GET();
+
+    expect(res.status).toBe(401);
+    expect(user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("404 when the session user is not found in the DB", async () => {
+    mGetSession.mockResolvedValue(AUTHED_SESSION as never);
+    user.findUnique.mockResolvedValue(null);
+
+    const res = await GET();
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("User not found");
+  });
+
+  it("queries prisma.user.findUnique with the session's user id and the ACTIVE-tokens-only include", async () => {
+    mGetSession.mockResolvedValue(AUTHED_SESSION as never);
+    user.findUnique.mockResolvedValue({
+      id: "user-1",
+      email: "u@test.com",
+      githubPat: "ghp_mockedTokenValue",
+      apiTokens: [],
+    });
+
+    await GET();
+
+    expect(user.findUnique).toHaveBeenCalledTimes(1);
+    expect(user.findUnique).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      include: {
+        apiTokens: {
+          where: { revokedAt: null },
+          orderBy: { createdAt: "desc" },
+        },
+      },
+    });
+  });
+
+  it("200 happy path returns the user (including raw githubPat, per the resolved decision) and their active tokens", async () => {
+    mGetSession.mockResolvedValue(AUTHED_SESSION as never);
+    const createdAt = new Date("2026-01-01T00:00:00.000Z");
+    const lastUsedAt = new Date("2026-01-02T00:00:00.000Z");
+    user.findUnique.mockResolvedValue({
+      id: "user-1",
+      email: "u@test.com",
+      githubPat: "ghp_mockedTokenValue",
+      apiTokens: [
+        {
+          id: "tok-1",
+          name: "ci",
+          token: "pf_abc123",
+          lastUsedAt,
+          createdAt,
+        },
+      ],
+    });
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.user).toEqual({
+      id: "user-1",
+      email: "u@test.com",
+      githubPat: "ghp_mockedTokenValue",
+    });
+    // Resolved decision: raw PAT IS present in the owner's own dashboard response.
+    expect(body.user.githubPat).toBe("ghp_mockedTokenValue");
+    expect(body.tokens).toEqual([
+      {
+        id: "tok-1",
+        name: "ci",
+        token: "pf_abc123",
+        lastUsedAt: lastUsedAt.toISOString(),
+        createdAt: createdAt.toISOString(),
+      },
+    ]);
+  });
+});

--- a/tests/unit/ai-provider.test.ts
+++ b/tests/unit/ai-provider.test.ts
@@ -176,8 +176,13 @@ describe('generateStructuredJson', () => {
     });
 
     it('parses JSON wrapped in a ```json fenced code block', async () => {
+      // The trailing '{oops}' is deliberate and makes this test DISCRIMINATE the
+      // fenced branch: with it present, the brace-substring fallback would slice
+      // from the first '{' to this last '}' (across the fence markers), yielding
+      // invalid JSON that throws. So the test only passes when the fenced-block
+      // branch actually parses the fence — removing that branch fails this test.
       mockCreate.mockResolvedValue(
-        completionWith('Here you go:\n```json\n{"foo":"fenced"}\n```\nHope that helps!')
+        completionWith('Here you go:\n```json\n{"foo":"fenced"}\n```\nAlso note: {oops}')
       );
 
       const result = await generateStructuredJson<Parsed>('sys', 'user');

--- a/tests/unit/ai-provider.test.ts
+++ b/tests/unit/ai-provider.test.ts
@@ -1,12 +1,33 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { getAiCapabilities } from '@/lib/ai-provider';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 /**
- * Unit tests for lib/ai-provider.ts — getAiCapabilities() is a pure
- * env-reading function. Tests all 4 provider branches by toggling env vars.
+ * Unit tests for lib/ai-provider.ts.
  *
- * generateStructuredJson requires an OpenAI SDK mock and is deferred.
+ * getAiCapabilities() is a pure env-reading function — tests all 4 provider
+ * branches by toggling env vars.
+ *
+ * generateStructuredJson() (and, through it, the private parseJsonObject
+ * branches: valid JSON / fenced code block / brace-substring extraction from
+ * prose / empty-response throw / not-valid-JSON throw) is exercised through
+ * a mocked OpenAI SDK client, since parseJsonObject itself is not exported.
  */
+
+const { mockCreate, mockOpenAiCtor } = vi.hoisted(() => ({
+  mockCreate: vi.fn(),
+  mockOpenAiCtor: vi.fn(),
+}));
+
+vi.mock('openai', () => ({
+  // Regular function (not arrow) so it can be called with `new`, matching
+  // the `new OpenAI(...)` call site in lib/ai-provider.ts.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: vi.fn(function MockOpenAI(this: any, config: unknown) {
+    mockOpenAiCtor(config);
+    this.chat = { completions: { create: mockCreate } };
+  }),
+}));
+
+import { getAiCapabilities, generateStructuredJson } from '@/lib/ai-provider';
 
 // AI env var keys managed by these tests
 const AI_ENV_KEYS = [
@@ -27,6 +48,8 @@ beforeEach(() => {
     saved[key] = process.env[key];
     delete process.env[key];
   }
+  mockCreate.mockReset();
+  mockOpenAiCtor.mockReset();
 });
 
 afterEach(() => {
@@ -118,6 +141,154 @@ describe('getAiCapabilities', () => {
       expect(caps.features.magicFill).toBe(false);
       expect(caps.features.intakeEnrichment).toBe(false);
       expect(caps.features.postScaffoldReview).toBe(false);
+    });
+  });
+});
+
+function completionWith(content: string | null | undefined) {
+  return { choices: [{ message: { content } }] };
+}
+
+interface Parsed {
+  foo: string;
+}
+
+describe('generateStructuredJson', () => {
+  it('rejects with "No AI provider configured" when no AI env vars are set, without touching the OpenAI SDK', async () => {
+    await expect(generateStructuredJson('sys', 'user')).rejects.toThrow('No AI provider configured');
+    expect(mockOpenAiCtor).not.toHaveBeenCalled();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  describe('parseJsonObject branches (exercised through the parsed content)', () => {
+    beforeEach(() => {
+      process.env.OPENAI_API_KEY = 'sk-test-key';
+    });
+
+    it('parses a plain JSON object response', async () => {
+      mockCreate.mockResolvedValue(completionWith('{"foo":"bar"}'));
+
+      const result = await generateStructuredJson<Parsed>('sys', 'user');
+
+      expect(result.data).toEqual({ foo: 'bar' });
+      expect(result.provider).toBe('openai');
+      expect(result.model).toBe('gpt-4o-mini');
+    });
+
+    it('parses JSON wrapped in a ```json fenced code block', async () => {
+      mockCreate.mockResolvedValue(
+        completionWith('Here you go:\n```json\n{"foo":"fenced"}\n```\nHope that helps!')
+      );
+
+      const result = await generateStructuredJson<Parsed>('sys', 'user');
+
+      expect(result.data).toEqual({ foo: 'fenced' });
+    });
+
+    it('extracts a JSON object via brace-substring from surrounding prose (no fence)', async () => {
+      mockCreate.mockResolvedValue(
+        completionWith('Sure, the result is {"foo":"prose"} — let me know if you need more.')
+      );
+
+      const result = await generateStructuredJson<Parsed>('sys', 'user');
+
+      expect(result.data).toEqual({ foo: 'prose' });
+    });
+
+    it('throws "AI returned an empty response" for an empty string response', async () => {
+      mockCreate.mockResolvedValue(completionWith(''));
+
+      await expect(generateStructuredJson('sys', 'user')).rejects.toThrow('AI returned an empty response');
+    });
+
+    it('throws "AI returned an empty response" for a whitespace-only (blank) response', async () => {
+      mockCreate.mockResolvedValue(completionWith('   \n\t  '));
+
+      await expect(generateStructuredJson('sys', 'user')).rejects.toThrow('AI returned an empty response');
+    });
+
+    it('throws "AI returned an empty response" when message.content is missing entirely', async () => {
+      mockCreate.mockResolvedValue({ choices: [{ message: {} }] });
+
+      await expect(generateStructuredJson('sys', 'user')).rejects.toThrow('AI returned an empty response');
+    });
+
+    it('throws "AI response was not valid JSON" for prose with no braces and no fence (malformed response)', async () => {
+      mockCreate.mockResolvedValue(completionWith('Sorry, I cannot help with that request.'));
+
+      await expect(generateStructuredJson('sys', 'user')).rejects.toThrow('AI response was not valid JSON');
+    });
+  });
+
+  describe('API-error branch', () => {
+    it('propagates a rejected OpenAI SDK call (e.g. network/rate-limit error)', async () => {
+      process.env.OPENAI_API_KEY = 'sk-test-key';
+      mockCreate.mockRejectedValue(new Error('OpenAI API rate limit exceeded'));
+
+      await expect(generateStructuredJson('sys', 'user')).rejects.toThrow('OpenAI API rate limit exceeded');
+    });
+  });
+
+  describe('provider-specific request shaping', () => {
+    it('omits response_format for the local provider', async () => {
+      process.env.LOCAL_AI_BASE_URL = 'http://localhost:11434';
+      process.env.LOCAL_AI_MODEL = 'llama3';
+      mockCreate.mockResolvedValue(completionWith('{"foo":"local"}'));
+
+      await generateStructuredJson<Parsed>('sys', 'user');
+
+      const callArg = mockCreate.mock.calls[0][0];
+      expect(callArg.response_format).toBeUndefined();
+      expect(callArg.model).toBe('llama3');
+    });
+
+    it('includes response_format: json_object for hosted providers (openai)', async () => {
+      process.env.OPENAI_API_KEY = 'sk-test-key';
+      mockCreate.mockResolvedValue(completionWith('{"foo":"hosted"}'));
+
+      await generateStructuredJson<Parsed>('sys', 'user');
+
+      const callArg = mockCreate.mock.calls[0][0];
+      expect(callArg.response_format).toEqual({ type: 'json_object' });
+    });
+
+    it('defaults temperature to 0.2 and max_tokens to 800 when options are omitted', async () => {
+      process.env.OPENAI_API_KEY = 'sk-test-key';
+      mockCreate.mockResolvedValue(completionWith('{"foo":"defaults"}'));
+
+      await generateStructuredJson<Parsed>('sys', 'user');
+
+      const callArg = mockCreate.mock.calls[0][0];
+      expect(callArg.temperature).toBe(0.2);
+      expect(callArg.max_tokens).toBe(800);
+    });
+
+    it('honors explicit temperature and maxTokens overrides', async () => {
+      process.env.OPENAI_API_KEY = 'sk-test-key';
+      mockCreate.mockResolvedValue(completionWith('{"foo":"override"}'));
+
+      await generateStructuredJson<Parsed>('sys', 'user', { temperature: 0.9, maxTokens: 42 });
+
+      const callArg = mockCreate.mock.calls[0][0];
+      expect(callArg.temperature).toBe(0.9);
+      expect(callArg.max_tokens).toBe(42);
+    });
+
+    it('constructs the OpenAI client with the provider apiKey and baseURL, and sends system+user messages', async () => {
+      process.env.GROQ_API_KEY = 'gsk_test_key';
+      mockCreate.mockResolvedValue(completionWith('{"foo":"groq"}'));
+
+      await generateStructuredJson<Parsed>('system prompt text', 'user prompt text');
+
+      expect(mockOpenAiCtor).toHaveBeenCalledWith({
+        apiKey: 'gsk_test_key',
+        baseURL: 'https://api.groq.com/openai/v1',
+      });
+      const callArg = mockCreate.mock.calls[0][0];
+      expect(callArg.messages).toEqual([
+        { role: 'system', content: 'system prompt text' },
+        { role: 'user', content: 'user prompt text' },
+      ]);
     });
   });
 });

--- a/tests/unit/github.test.ts
+++ b/tests/unit/github.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { fetchGitHubUser, GitHubAuthError, GitHubUnreachableError } from "@/lib/github";
+
+/**
+ * Unit tests for lib/github.ts fetchGitHubUser — asserts the error
+ * CLASSES returned for each failure mode (network error vs 401/403/404
+ * vs 5xx), not just that a throw happens, since callers branch on
+ * `instanceof`.
+ */
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("fetchGitHubUser", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("throws GitHubUnreachableError when fetch itself rejects (network error)", async () => {
+    fetchSpy.mockRejectedValue(new TypeError("fetch failed"));
+
+    await expect(fetchGitHubUser("tok")).rejects.toBeInstanceOf(GitHubUnreachableError);
+  });
+
+  it("network-error message includes the underlying error text", async () => {
+    fetchSpy.mockRejectedValue(new TypeError("ECONNRESET"));
+
+    await expect(fetchGitHubUser("tok")).rejects.toThrow(/Could not reach GitHub: ECONNRESET/);
+  });
+
+  it("throws GitHubAuthError (not GitHubUnreachableError) on 401", async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(401, { message: "Bad credentials" }));
+
+    const err = await fetchGitHubUser("tok").catch((e) => e);
+    expect(err).toBeInstanceOf(GitHubAuthError);
+    expect(err).not.toBeInstanceOf(GitHubUnreachableError);
+  });
+
+  it("throws GitHubAuthError on 403", async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(403, { message: "Forbidden" }));
+
+    await expect(fetchGitHubUser("tok")).rejects.toBeInstanceOf(GitHubAuthError);
+  });
+
+  it("throws GitHubAuthError on 404", async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(404, { message: "Not Found" }));
+
+    await expect(fetchGitHubUser("tok")).rejects.toBeInstanceOf(GitHubAuthError);
+  });
+
+  it("throws GitHubUnreachableError (not GitHubAuthError) on 500", async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(500, { message: "Internal Server Error" }));
+
+    const err = await fetchGitHubUser("tok").catch((e) => e);
+    expect(err).toBeInstanceOf(GitHubUnreachableError);
+    expect(err).not.toBeInstanceOf(GitHubAuthError);
+  });
+
+  it("throws GitHubUnreachableError on 503", async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(503, { message: "Service Unavailable" }));
+
+    await expect(fetchGitHubUser("tok")).rejects.toBeInstanceOf(GitHubUnreachableError);
+  });
+
+  it("resolves with the parsed user object on 200", async () => {
+    const ghUser = {
+      id: 12345,
+      login: "octocat",
+      name: "The Octocat",
+      avatar_url: "https://example.com/avatar.png",
+      email: "octocat@example.com",
+    };
+    fetchSpy.mockResolvedValue(jsonResponse(200, ghUser));
+
+    const result = await fetchGitHubUser("tok");
+
+    expect(result).toEqual(ghUser);
+  });
+
+  it("sends the access token as a Bearer Authorization header against api.github.com/user", async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, { id: 1, login: "x", name: null, avatar_url: "", email: null })
+    );
+
+    await fetchGitHubUser("my-token-123");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.github.com/user",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer my-token-123",
+          Accept: "application/vnd.github+json",
+        }),
+      })
+    );
+  });
+});

--- a/tests/unit/v1-shared.test.ts
+++ b/tests/unit/v1-shared.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from "vitest";
-import { validateProjectName, SESSION_UUID_RE, SESSION_TTL_MS, isSessionExpired } from "@/lib/v1-shared";
+import { describe, expect, it, afterEach } from "vitest";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import {
+  validateProjectName,
+  SESSION_UUID_RE,
+  SESSION_TTL_MS,
+  isSessionExpired,
+  readForgeMeta,
+  parseTasks,
+  buildFileTree,
+  readPreviewData,
+} from "@/lib/v1-shared";
 import type { ForgeMeta } from "@/lib/v1-shared";
 
 describe("validateProjectName", () => {
@@ -118,5 +130,267 @@ describe("isSessionExpired", () => {
   it("returns false for a session created at TTL - 1ms (just under boundary)", () => {
     const meta = metaWithAge(SESSION_TTL_MS - 1);
     expect(isSessionExpired(meta)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readForgeMeta / parseTasks / buildFileTree / readPreviewData
+//
+// These operate on real filesystem temp dirs (fs.mkdtemp) rather than mocks,
+// since resolvePlanforgeOutputPaths already degrades gracefully to
+// tempDir-relative default paths when no planforge-index.json is present —
+// no need to mock it for these direct-artifact-layout tests.
+// ---------------------------------------------------------------------------
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "v1-shared-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("readForgeMeta", () => {
+  it("parses a valid .forge-meta.json from the temp dir", async () => {
+    const dir = await makeTempDir();
+    const meta: ForgeMeta = {
+      tokenId: "tok-1",
+      userId: "user-1",
+      projectName: "my-project",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+    await fs.writeFile(path.join(dir, ".forge-meta.json"), JSON.stringify(meta));
+
+    const result = await readForgeMeta(dir);
+
+    expect(result).toEqual(meta);
+  });
+
+  it("parses meta without the optional tokenId field", async () => {
+    const dir = await makeTempDir();
+    const meta = { userId: "user-2", projectName: "legacy-project", createdAt: "2026-02-01T00:00:00.000Z" };
+    await fs.writeFile(path.join(dir, ".forge-meta.json"), JSON.stringify(meta));
+
+    const result = await readForgeMeta(dir);
+
+    expect(result).toEqual(meta);
+    expect(result.tokenId).toBeUndefined();
+  });
+
+  it("rejects when .forge-meta.json does not exist", async () => {
+    const dir = await makeTempDir();
+
+    await expect(readForgeMeta(dir)).rejects.toThrow();
+  });
+});
+
+describe("parseTasks", () => {
+  it("returns [] when the tasks dir does not exist", async () => {
+    const dir = await makeTempDir();
+
+    const tasks = await parseTasks(dir);
+
+    expect(tasks).toEqual([]);
+  });
+
+  it("parses id/title/wave/category/priority/summary from a fully-formed task file", async () => {
+    const dir = await makeTempDir();
+    const tasksDir = path.join(dir, "tasks");
+    await fs.mkdir(tasksDir, { recursive: true });
+    await fs.writeFile(
+      path.join(tasksDir, "01-setup.md"),
+      [
+        "# Task 1: Setup the project",
+        "",
+        "## Wave",
+        "",
+        "wave-1",
+        "",
+        "## Category",
+        "",
+        "feature",
+        "",
+        "## Priority",
+        "",
+        "P1",
+        "",
+        "## Summary",
+        "",
+        "Bootstrap the repo scaffolding.",
+        "",
+      ].join("\n")
+    );
+
+    const tasks = await parseTasks(dir);
+
+    expect(tasks).toEqual([
+      {
+        id: "01",
+        title: "Setup the project",
+        wave: "wave-1",
+        category: "feature",
+        priority: "P1",
+        summary: "Bootstrap the repo scaffolding.",
+      },
+    ]);
+  });
+
+  it("falls back to filename-derived id/title and default wave/category/priority when fields are missing, and leaves summary undefined", async () => {
+    const dir = await makeTempDir();
+    const tasksDir = path.join(dir, "tasks");
+    await fs.mkdir(tasksDir, { recursive: true });
+    await fs.writeFile(path.join(tasksDir, "no-frontmatter.md"), "Just some unstructured content.");
+
+    const tasks = await parseTasks(dir);
+
+    expect(tasks).toEqual([
+      {
+        id: "no-frontmatter",
+        title: "no-frontmatter.md",
+        wave: "wave-1",
+        category: "feature",
+        priority: "P1",
+        summary: undefined,
+      },
+    ]);
+  });
+
+  it("ignores non-.md files in the tasks dir", async () => {
+    const dir = await makeTempDir();
+    const tasksDir = path.join(dir, "tasks");
+    await fs.mkdir(tasksDir, { recursive: true });
+    await fs.writeFile(path.join(tasksDir, "01-real.md"), "# Task 1: Real task\n");
+    await fs.writeFile(path.join(tasksDir, "notes.txt"), "not a task");
+
+    const tasks = await parseTasks(dir);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].id).toBe("01");
+  });
+
+  it("parses multiple task files", async () => {
+    const dir = await makeTempDir();
+    const tasksDir = path.join(dir, "tasks");
+    await fs.mkdir(tasksDir, { recursive: true });
+    await fs.writeFile(path.join(tasksDir, "01-a.md"), "# Task 1: First\n\n## Wave\n\nwave-1\n");
+    await fs.writeFile(path.join(tasksDir, "02-b.md"), "# Task 2: Second\n\n## Wave\n\nwave-2\n");
+
+    const tasks = await parseTasks(dir);
+
+    expect(tasks.map((t) => t.id).sort()).toEqual(["01", "02"]);
+    expect(tasks.map((t) => t.wave).sort()).toEqual(["wave-1", "wave-2"]);
+  });
+});
+
+describe("buildFileTree", () => {
+  it("sorts directories before files, and alphabetically within each group", async () => {
+    const dir = await makeTempDir();
+    await fs.mkdir(path.join(dir, "zdir"), { recursive: true });
+    await fs.writeFile(path.join(dir, "zdir", "inner.txt"), "inner");
+    await fs.writeFile(path.join(dir, "afile.txt"), "content");
+
+    const tree = await buildFileTree(dir);
+
+    expect(tree).toEqual([
+      {
+        name: "zdir",
+        path: "zdir",
+        type: "directory",
+        children: [{ name: "inner.txt", path: "zdir/inner.txt", type: "file" }],
+      },
+      { name: "afile.txt", path: "afile.txt", type: "file" },
+    ]);
+  });
+
+  it("skips node_modules, .git, venv, and __pycache__ directories", async () => {
+    const dir = await makeTempDir();
+    await fs.mkdir(path.join(dir, "node_modules"), { recursive: true });
+    await fs.writeFile(path.join(dir, "node_modules", "pkg.json"), "{}");
+    await fs.mkdir(path.join(dir, ".git"), { recursive: true });
+    await fs.writeFile(path.join(dir, ".git", "HEAD"), "ref: refs/heads/main");
+    await fs.mkdir(path.join(dir, "venv"), { recursive: true });
+    await fs.writeFile(path.join(dir, "venv", "pyvenv.cfg"), "");
+    await fs.mkdir(path.join(dir, "__pycache__"), { recursive: true });
+    await fs.writeFile(path.join(dir, "__pycache__", "cache.pyc"), "");
+    await fs.writeFile(path.join(dir, "keep.txt"), "kept");
+
+    const tree = await buildFileTree(dir);
+
+    expect(tree).toEqual([{ name: "keep.txt", path: "keep.txt", type: "file" }]);
+  });
+
+  it("skips .forge-meta.json and .forge-published files", async () => {
+    const dir = await makeTempDir();
+    await fs.writeFile(path.join(dir, ".forge-meta.json"), "{}");
+    await fs.writeFile(path.join(dir, ".forge-published"), "");
+    await fs.writeFile(path.join(dir, "README.md"), "# hi");
+
+    const tree = await buildFileTree(dir);
+
+    expect(tree).toEqual([{ name: "README.md", path: "README.md", type: "file" }]);
+  });
+
+  it("recurses into nested subdirectories, tracking relative paths", async () => {
+    const dir = await makeTempDir();
+    await fs.mkdir(path.join(dir, "a", "b"), { recursive: true });
+    await fs.writeFile(path.join(dir, "a", "b", "deep.txt"), "deep");
+
+    const tree = await buildFileTree(dir);
+
+    expect(tree).toEqual([
+      {
+        name: "a",
+        path: "a",
+        type: "directory",
+        children: [
+          {
+            name: "b",
+            path: "a/b",
+            type: "directory",
+            children: [{ name: "deep.txt", path: "a/b/deep.txt", type: "file" }],
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe("readPreviewData", () => {
+  it("returns safe defaults for a completely empty temp dir (no tasks, no artifacts)", async () => {
+    const dir = await makeTempDir();
+
+    const preview = await readPreviewData(dir, "empty-project");
+
+    expect(preview.projectName).toBe("empty-project");
+    expect(preview.tasks).toEqual([]);
+    expect(preview.taskCount).toBe(0);
+    expect(preview.waveCount).toBe(0);
+    expect(preview.architectureOverview).toBe("(not generated)");
+    // No scaffoldkit-input.json present -> readScaffoldPreview falls back to
+    // the planning-baseline status.
+    expect(preview.scaffold.status).toBe("planning-baseline");
+    // No post-scaffold-review.json present -> toScaffoldFitPreview(null) is undefined.
+    expect(preview.scaffoldFit).toBeUndefined();
+  });
+
+  it("aggregates tasks, architecture overview content, taskCount, and waveCount when artifacts are present", async () => {
+    const dir = await makeTempDir();
+    const tasksDir = path.join(dir, "tasks");
+    await fs.mkdir(tasksDir, { recursive: true });
+    await fs.writeFile(path.join(tasksDir, "01-a.md"), "# Task 1: First\n\n## Wave\n\nwave-1\n");
+    await fs.writeFile(path.join(tasksDir, "02-b.md"), "# Task 2: Second\n\n## Wave\n\nwave-2\n");
+    await fs.writeFile(path.join(dir, "architecture-overview.md"), "# Architecture\n\nSome overview text.");
+
+    const preview = await readPreviewData(dir, "real-project");
+
+    expect(preview.projectName).toBe("real-project");
+    expect(preview.taskCount).toBe(2);
+    expect(preview.waveCount).toBe(2);
+    expect(preview.architectureOverview).toBe("# Architecture\n\nSome overview text.");
+    expect(preview.tasks.map((t) => t.id).sort()).toEqual(["01", "02"]);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,9 +38,17 @@ export default defineConfig({
         'app/api/generate/route.ts': { statements: 80, branches: 50, functions: 55, lines: 83 },
         // Measured: stmts 75, branches 50, funcs 83, lines 83
         'lib/subprocess.ts': { statements: 70, branches: 45, functions: 78, lines: 78 },
-        // Measured: stmts 39, branches 40, funcs 50, lines 39
-        // Low because generateStructuredJson is deferred (needs OpenAI SDK mock)
-        'lib/ai-provider.ts': { statements: 36, branches: 37, functions: 47, lines: 36 },
+        // Measured: stmts 100, branches 100, funcs 100, lines 100 — now fully
+        // covered via a mocked OpenAI SDK (generateStructuredJson success,
+        // malformed-response, and API-error branches; parseJsonObject's
+        // fenced/prose/empty branches exercised through it).
+        'lib/ai-provider.ts': { statements: 95, branches: 95, functions: 95, lines: 95 },
+        // Measured: stmts 100, branches 100, funcs 100, lines 100
+        'app/api/dashboard/route.ts': { statements: 95, branches: 90, functions: 95, lines: 95 },
+        // Measured: stmts 100, branches 100, funcs 100, lines 100
+        'lib/github.ts': { statements: 95, branches: 90, functions: 95, lines: 95 },
+        // Measured: stmts 98, branches 96.29, funcs 100, lines 100
+        'lib/v1-shared.ts': { statements: 93, branches: 91, functions: 95, lines: 95 },
       },
     },
   },


### PR DESCRIPTION
## What

project-forge test-coverage MED tail (test-only plus per-file floors). Follow-up to #104/#105. Task c8fa9023.

## Security decision

GET /api/dashboard returns the caller's own githubPat raw. It is session-gated and owner-only, so it is not a cross-user leak. Operator decision (2026-07-01): this is intentional; the test encodes the PAT as present. Reducing the exposure (two consumer pages only need a boolean) is tracked as a follow-up (e5a2529c).

## Tests (42 new; suite 210 to 252)

- dashboard-route: 401 no session, 404 no user, 200 with exact user-scoped findUnique args (apiTokens where revokedAt:null), and the githubPat-present assertion. Mutation-verified: inverting the session gate or removing the token scoping fails a test.
- ai-provider: parseJsonObject branches (valid, fenced json, brace-substring, empty-throw) via the public generateStructuredJson, plus generateStructuredJson success, malformed, and API-error over a mocked OpenAI SDK. The fenced test is discriminating (a disabled fenced branch fails it).
- github fetchGitHubUser: network to GitHubUnreachableError, 401/403/404 to GitHubAuthError, 5xx to GitHubUnreachableError, 200 to parsed user.
- v1-shared: parseTasks, readPreviewData, buildFileTree, readForgeMeta over real temp dirs.

Per-file coverage floors added (measured, floored below, negative-control verified). Reviewed adversarially: both security guards are mutation-caught; the one review nit (fenced test green-for-wrong-reason) is fixed and re-verified. Full suite 252 pass, typecheck and lint clean.

Refs: project-forge task c8fa9023