### PR TITLE
fix(security): stop returning the raw githubPat from GET /api/dashboard

### DIFF
--- a/app/(dashboard)/create/page.tsx
+++ b/app/(dashboard)/create/page.tsx
@@ -63,7 +63,7 @@ export default function CreatePage() {
         .then((r) => r.json())
         .then((data) => {
           if (data.ok) {
-            setGithubConnected(!!(data.user.githubPat || data.user.githubOwner));
+            setGithubConnected(!!(data.user.githubPatConnected || data.user.githubOwner));
           } else {
             setGithubConnected(false);
           }

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -23,7 +23,7 @@ export default function DashboardPage() {
         .then((data) => {
           if (data.ok) {
             setGithubConnected(
-              !!(data.user.githubPat || data.user.githubOwner),
+              !!(data.user.githubPatConnected || data.user.githubOwner),
             );
           }
           setLoaded(true);

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -43,14 +43,20 @@ export default function SettingsPage() {
 
   const loadData = async () => {
     try {
-      const res = await fetch("/api/dashboard");
+      const [res, patRes] = await Promise.all([
+        fetch("/api/dashboard"),
+        fetch("/api/dashboard/pat"),
+      ]);
       const data = await res.json();
+      const patData = await patRes.json();
       if (data.ok) {
-        setGithubPat(data.user.githubPat || "");
-        setGithubConnectedViaOAuth(
-          !!(data.user.githubPat?.startsWith("gho_") || data.user.githubOwner),
-        );
         setTokens(data.tokens || []);
+      }
+      if (patData.ok) {
+        setGithubPat(patData.githubPat || "");
+        setGithubConnectedViaOAuth(
+          !!(patData.githubPat?.startsWith("gho_") || data.user?.githubOwner),
+        );
       }
     } catch (err) {
       console.error("Failed to load settings:", err);

--- a/app/api/dashboard/pat/route.ts
+++ b/app/api/dashboard/pat/route.ts
@@ -3,6 +3,29 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 
+// Settings-only: the caller's own raw GitHub PAT. The shared GET /api/dashboard
+// response only exposes a `githubPatConnected` boolean (see app/api/dashboard/route.ts)
+// because most consumers only need existence; the settings page pre-fills/edits
+// the token and needs the raw value, scoped strictly to the authenticated owner.
+export async function GET() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { githubPat: true },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ ok: true, githubPat: user.githubPat });
+}
+
 export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
 

--- a/app/api/dashboard/pat/route.ts
+++ b/app/api/dashboard/pat/route.ts
@@ -23,7 +23,11 @@ export async function GET() {
     return NextResponse.json({ error: "User not found" }, { status: 404 });
   }
 
-  return NextResponse.json({ ok: true, githubPat: user.githubPat });
+  // Secret-bearing response: forbid any intermediary/browser caching.
+  return NextResponse.json(
+    { ok: true, githubPat: user.githubPat },
+    { headers: { "Cache-Control": "no-store, max-age=0" } }
+  );
 }
 
 export async function POST(req: NextRequest) {

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -29,7 +29,7 @@ export async function GET() {
     user: {
       id: user.id,
       email: user.email,
-      githubPat: user.githubPat,
+      githubPatConnected: !!user.githubPat,
     },
     tokens: user.apiTokens.map((t) => ({
       id: t.id,

--- a/tests/integration/dashboard-route.test.ts
+++ b/tests/integration/dashboard-route.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 /**
  * Integration tests for GET /api/dashboard.
  *
- * SECURITY NOTE (resolved, do not re-litigate): the route intentionally
- * returns the caller's own `githubPat` in the response body — this is the
- * owner viewing their own PAT, and the settings page relies on it. These
- * tests assert that value is present, not scrub it.
+ * SECURITY NOTE: the route no longer returns the caller's raw `githubPat`.
+ * Only two of its three consumers (dashboard/page.tsx, create/page.tsx) need
+ * existence, so the route now returns a `githubPatConnected` boolean instead.
+ * The settings page, which pre-fills/edits the raw token, reads it from the
+ * dedicated GET /api/dashboard/pat endpoint (see dashboard-token-management.test.ts).
+ * These tests assert the raw PAT is absent and the boolean is present.
  */
 
 vi.mock("next-auth", () => ({
@@ -100,7 +102,7 @@ describe("GET /api/dashboard", () => {
     });
   });
 
-  it("200 happy path returns the user (including raw githubPat, per the resolved decision) and their active tokens", async () => {
+  it("200 happy path returns githubPatConnected: true (never the raw PAT) plus active tokens, when a PAT is set", async () => {
     mGetSession.mockResolvedValue(AUTHED_SESSION as never);
     const createdAt = new Date("2026-01-01T00:00:00.000Z");
     const lastUsedAt = new Date("2026-01-02T00:00:00.000Z");
@@ -127,10 +129,11 @@ describe("GET /api/dashboard", () => {
     expect(body.user).toEqual({
       id: "user-1",
       email: "u@test.com",
-      githubPat: "ghp_mockedTokenValue",
+      githubPatConnected: true,
     });
-    // Resolved decision: raw PAT IS present in the owner's own dashboard response.
-    expect(body.user.githubPat).toBe("ghp_mockedTokenValue");
+    // The raw PAT must never appear anywhere in the response body.
+    expect(body.user.githubPat).toBeUndefined();
+    expect(JSON.stringify(body)).not.toContain("ghp_mockedTokenValue");
     expect(body.tokens).toEqual([
       {
         id: "tok-1",
@@ -140,5 +143,25 @@ describe("GET /api/dashboard", () => {
         createdAt: createdAt.toISOString(),
       },
     ]);
+  });
+
+  it("200 happy path returns githubPatConnected: false when the user has no PAT set", async () => {
+    mGetSession.mockResolvedValue(AUTHED_SESSION as never);
+    user.findUnique.mockResolvedValue({
+      id: "user-1",
+      email: "u@test.com",
+      githubPat: null,
+      apiTokens: [],
+    });
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user).toEqual({
+      id: "user-1",
+      email: "u@test.com",
+      githubPatConnected: false,
+    });
   });
 });

--- a/tests/integration/dashboard-token-management.test.ts
+++ b/tests/integration/dashboard-token-management.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/lib/db", async () => {
       },
       user: {
         update: vi.fn(),
+        findUnique: vi.fn(),
       },
     },
     // Keep the real generateApiToken so we can assert pf_ prefix
@@ -36,7 +37,7 @@ import { getServerSession } from "next-auth";
 import { prisma } from "@/lib/db";
 import { POST as createToken } from "@/app/api/dashboard/tokens/route";
 import { DELETE as revokeToken } from "@/app/api/dashboard/tokens/[id]/route";
-import { POST as savePat } from "@/app/api/dashboard/pat/route";
+import { GET as getPat, POST as savePat } from "@/app/api/dashboard/pat/route";
 
 const mGetSession = vi.mocked(getServerSession);
 
@@ -48,6 +49,7 @@ const apiToken = prisma.apiToken as unknown as {
 
 const user = prisma.user as unknown as {
   update: ReturnType<typeof vi.fn>;
+  findUnique: ReturnType<typeof vi.fn>;
 };
 
 function jsonReq(url: string, body: unknown, method = "POST"): NextRequest {
@@ -201,6 +203,72 @@ describe("DELETE /api/dashboard/tokens/[id]", () => {
     expect(apiToken.update).toHaveBeenCalledTimes(1);
     const updateArg = apiToken.update.mock.calls[0][0];
     expect(updateArg.data.revokedAt).toBeInstanceOf(Date);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/dashboard/pat  (settings-only: read the caller's own raw PAT)
+// ---------------------------------------------------------------------------
+describe("GET /api/dashboard/pat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("401 when there is no session", async () => {
+    mGetSession.mockResolvedValue(null);
+
+    const res = await getPat();
+
+    expect(res.status).toBe(401);
+    expect(user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("404 when the session user is not found in the DB", async () => {
+    mGetSession.mockResolvedValue(AUTHED_SESSION as never);
+    user.findUnique.mockResolvedValue(null);
+
+    const res = await getPat();
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("User not found");
+  });
+
+  it("scopes the lookup to the session's own user id", async () => {
+    mGetSession.mockResolvedValue(AUTHED_SESSION as never);
+    user.findUnique.mockResolvedValue({ githubPat: "ghp_mine" });
+
+    await getPat();
+
+    expect(user.findUnique).toHaveBeenCalledTimes(1);
+    expect(user.findUnique).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      select: { githubPat: true },
+    });
+  });
+
+  it("200 returns the caller's own raw githubPat", async () => {
+    mGetSession.mockResolvedValue(AUTHED_SESSION as never);
+    user.findUnique.mockResolvedValue({ githubPat: "ghp_ownRawToken" });
+
+    const res = await getPat();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.githubPat).toBe("ghp_ownRawToken");
+  });
+
+  it("200 returns null githubPat when the user has none set", async () => {
+    mGetSession.mockResolvedValue(AUTHED_SESSION as never);
+    user.findUnique.mockResolvedValue({ githubPat: null });
+
+    const res = await getPat();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.githubPat).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What
GET /api/dashboard returned the caller's raw GitHub PAT, but two of its three consumers only need existence. Shipping the raw token to pages that need a boolean widens the XSS / client-logging blast radius.

## Changes
- GET /api/dashboard now returns `githubPatConnected: !!user.githubPat` and no longer includes the raw PAT.
- dashboard/page.tsx and create/page.tsx consume the boolean.
- settings/page.tsx fetches the raw PAT from a new owner-scoped, session-gated GET /api/dashboard/pat (added alongside the existing POST in the same route file); tokens and githubOwner stay on /api/dashboard.
- dashboard-route.test.ts asserts redaction (raw PAT absent incl. JSON substring check, boolean present, true and false branches); 401/404/scoping tests kept.
- dashboard-token-management.test.ts adds 5 tests for GET /api/dashboard/pat (401, 404, owner-scoped query args, raw value, null value).

## Verification
typecheck clean; eslint 0 errors (1 pre-existing unrelated warning); vitest coverage 23 files / 258 tests green with all gates; next build generates all 23 pages including the touched routes.

## Observations (out of scope, follow-up candidates)
- apiTokens[].token is still returned raw by the dashboard GET and rendered on settings; fixing it needs hashing at rest + show-once flow (task excludes token-management endpoints).
- GET /api/dashboard never included githubOwner, so the || data.user.githubOwner fallback in the consumer pages was always dead code; behavior preserved.
- The old test docstring declared the raw-PAT exposure settled (task c8fa9023); this task reverses that decision, docstring updated accordingly.

Refs: agent-tasks e5a2529c-a506-42b7-a1df-d35e60065879