### PR TITLE
fix(security): hash API tokens at rest and stop re-serving them on every dashboard load

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,12 @@ PLANFORGE_SERVICE_TOKEN=
 # (comma-separated). Unset/empty = accept any.
 # ALLOWED_GITHUB_LOGINS=
 
+# Key for hashing API tokens (pf_*) at rest (keyed SHA-256/HMAC). Defaults to
+# NEXTAUTH_SECRET when unset, so this is optional; set it to rotate the
+# token-hash key independently of the session secret. Rotating whichever key
+# is in effect invalidates every previously-issued API token.
+# API_TOKEN_HASH_SECRET=
+
 # Temp dir for build artifacts (defaults to /tmp/project-forge)
 # FORGE_TEMP_DIR=/tmp/project-forge
 

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -12,7 +12,7 @@ import { Button, Input, Card, CardHeader, Badge, Alert } from "@/components/ui/p
 interface ApiToken {
   id: string;
   name: string;
-  // Non-secret display hint only ("pf_ab12cd34"); the raw token is shown
+  // Non-secret display hint only ("pf_ab12cd3"); the raw token is shown
   // exactly once at creation (see newlyCreatedToken) and never again.
   tokenPrefix: string;
   lastUsedAt: string | null;

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -12,7 +12,9 @@ import { Button, Input, Card, CardHeader, Badge, Alert } from "@/components/ui/p
 interface ApiToken {
   id: string;
   name: string;
-  token: string;
+  // Non-secret display hint only ("pf_ab12cd34"); the raw token is shown
+  // exactly once at creation (see newlyCreatedToken) and never again.
+  tokenPrefix: string;
   lastUsedAt: string | null;
   createdAt: string;
 }
@@ -20,6 +22,32 @@ interface ApiToken {
 interface TokenToRevoke {
   id: string;
   name: string;
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      aria-label="Copy to clipboard"
+      className="ml-2 text-forge-ash hover:text-forge-mist transition shrink-0"
+      onClick={() => {
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }}
+    >
+      {copied ? (
+        <svg className="w-4 h-4 text-success" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+        </svg>
+      ) : (
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9.75a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" />
+        </svg>
+      )}
+    </button>
+  );
 }
 
 export default function SettingsPage() {
@@ -246,9 +274,12 @@ export default function SettingsPage() {
             {newlyCreatedToken && (
               <Alert variant="success" onClose={() => setNewlyCreatedToken(null)} className="mb-4">
                 <p className="font-medium mb-1">Token created! Copy it now, it won&apos;t be shown again.</p>
-                <code className="block bg-forge-steel rounded-btn px-3 py-2 font-mono text-sm text-success mt-2 break-all">
-                  {newlyCreatedToken}
-                </code>
+                <div className="flex items-center bg-forge-steel rounded-btn px-3 py-2 mt-2">
+                  <code className="font-mono text-sm text-success break-all flex-1">
+                    {newlyCreatedToken}
+                  </code>
+                  <CopyButton text={newlyCreatedToken} />
+                </div>
               </Alert>
             )}
 
@@ -260,7 +291,9 @@ export default function SettingsPage() {
                   <div key={token.id} className="flex items-center justify-between rounded-card bg-forge-steel/50 p-4">
                     <div className="flex-1 min-w-0">
                       <div className="font-medium text-forge-mist">{token.name}</div>
-                      <div className="text-sm font-mono text-forge-ash mt-1 truncate">{token.token}</div>
+                      <div className="text-sm font-mono text-forge-ash mt-1 truncate">
+                        {token.tokenPrefix}&hellip;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;
+                      </div>
                       <div className="text-xs text-forge-ash/70 mt-1">
                         Created: {new Date(token.createdAt).toLocaleDateString()} &middot;{" "}
                         Last used: {token.lastUsedAt ? new Date(token.lastUsedAt).toLocaleDateString() : "Never"}

--- a/app/api/auth/register-from-project-pilot/route.ts
+++ b/app/api/auth/register-from-project-pilot/route.ts
@@ -23,6 +23,13 @@
  * invariant the old reuse branch cared about, at the cost of no longer
  * being idempotent BY VALUE. The broker is documented to cache whatever's
  * returned and only re-register on 401, so this remains a rare path.
+ *
+ * Confirmed against the actual caller (project-pilot, backend/src/routes/oauth.ts:190):
+ * this endpoint's only caller is project-pilot's OAuth-completion handler,
+ * which persists the returned token encrypted via upsertCredential and has
+ * no automatic 401-triggered re-register loop — so the revoke-and-reissue
+ * behavior above cannot spuriously invalidate a token another concurrent
+ * "legitimate" flow is mid-use with.
  */
 import { NextRequest, NextResponse } from "next/server";
 import { prisma, createApiToken } from "@/lib/db";
@@ -180,22 +187,23 @@ export async function POST(req: NextRequest) {
         },
       });
 
-  // At most one active "project-pilot" token per user. Hash-at-rest means
-  // the raw value of an existing token can no longer be recovered, so a
-  // repeat call revokes it and issues a fresh one instead of returning the
-  // same value again (see file-level comment above).
-  const activeToken = await prisma.apiToken.findFirst({
-    where: { userId: user.id, revokedAt: null, name: "project-pilot" },
-    orderBy: { createdAt: "desc" },
-  });
-
-  if (activeToken) {
-    await prisma.apiToken.update({
-      where: { id: activeToken.id },
+  // At most one active "project-pilot" token per user, even under
+  // concurrent calls. Revoke via updateMany (a single atomic
+  // UPDATE ... WHERE revokedAt IS NULL) rather than findFirst-then-update-
+  // by-id, and run both statements in one transaction: two racing calls
+  // can't each read the same now-stale "active" row and then both revoke +
+  // create, which would leave two tokens active at once. The second call's
+  // updateMany also sweeps up the first call's freshly created row. Hash-
+  // at-rest means an existing token's raw value can no longer be recovered,
+  // so a repeat call issues a fresh one instead of returning the same value
+  // again (see file-level comment above).
+  const { raw: apiToken } = await prisma.$transaction(async (tx) => {
+    await tx.apiToken.updateMany({
+      where: { userId: user.id, name: "project-pilot", revokedAt: null },
       data: { revokedAt: new Date() },
     });
-  }
-  const { raw: apiToken } = await createApiToken(prisma, user.id, "project-pilot");
+    return createApiToken(tx, user.id, "project-pilot");
+  });
 
   return NextResponse.json({
     apiToken,

--- a/app/api/auth/register-from-project-pilot/route.ts
+++ b/app/api/auth/register-from-project-pilot/route.ts
@@ -24,12 +24,14 @@
  * being idempotent BY VALUE. The broker is documented to cache whatever's
  * returned and only re-register on 401, so this remains a rare path.
  *
- * Confirmed against the actual caller (project-pilot, backend/src/routes/oauth.ts:190):
- * this endpoint's only caller is project-pilot's OAuth-completion handler,
- * which persists the returned token encrypted via upsertCredential and has
- * no automatic 401-triggered re-register loop — so the revoke-and-reissue
- * behavior above cannot spuriously invalidate a token another concurrent
- * "legitimate" flow is mid-use with.
+ * Point-in-time cross-repo observation (as of 2026-07-14, per project-pilot
+ * backend/src/routes/oauth.ts:190): this endpoint's only caller is
+ * project-pilot's OAuth-completion handler, which persists the returned
+ * token encrypted via upsertCredential and has no automatic 401-triggered
+ * re-register loop — so the revoke-and-reissue behavior above cannot
+ * spuriously invalidate a token another concurrent "legitimate" flow is
+ * mid-use with. Re-check this against project-pilot if that call site
+ * changes.
  */
 import { NextRequest, NextResponse } from "next/server";
 import { prisma, createApiToken } from "@/lib/db";
@@ -197,6 +199,14 @@ export async function POST(req: NextRequest) {
   // at-rest means an existing token's raw value can no longer be recovered,
   // so a repeat call issues a fresh one instead of returning the same value
   // again (see file-level comment above).
+  //
+  // CAVEAT: the "no two active tokens" invariant above relies on this
+  // project's datasource being SQLite, which serializes writers (one
+  // writer transaction at a time) — there is no genuine cross-transaction
+  // race to close here. Porting this to a true MVCC datastore (Postgres,
+  // etc.) would need an explicit guard (a partial unique index on
+  // (userId, name) WHERE revokedAt IS NULL, or a row lock) for the same
+  // guarantee to hold under real concurrent writers.
   const { raw: apiToken } = await prisma.$transaction(async (tx) => {
     await tx.apiToken.updateMany({
       where: { userId: user.id, name: "project-pilot", revokedAt: null },

--- a/app/api/auth/register-from-project-pilot/route.ts
+++ b/app/api/auth/register-from-project-pilot/route.ts
@@ -14,12 +14,18 @@
  * broker cannot impersonate users because the token has to be valid.
  *
  * The returned apiToken is project-forge's own `pf_*` API token — the broker
- * stores it encrypted and forwards it on subsequent API calls. Idempotent:
- * a second call for the same GitHub identity returns the existing active
- * token rather than minting a new one.
+ * stores it encrypted and forwards it on subsequent API calls. API tokens
+ * are hashed at rest (see lib/db.ts hashApiToken()), so the raw value is
+ * never persisted and cannot be recovered on a later call: a second call
+ * for the same GitHub identity revokes the existing active token and mints
+ * a fresh one (invalidate + re-issue) rather than returning the same value
+ * again. This keeps the "at most one active project-pilot token per user"
+ * invariant the old reuse branch cared about, at the cost of no longer
+ * being idempotent BY VALUE. The broker is documented to cache whatever's
+ * returned and only re-register on 401, so this remains a rare path.
  */
 import { NextRequest, NextResponse } from "next/server";
-import { prisma, generateApiToken } from "@/lib/db";
+import { prisma, createApiToken } from "@/lib/db";
 import {
   fetchGitHubUser,
   GitHubAuthError,
@@ -174,27 +180,22 @@ export async function POST(req: NextRequest) {
         },
       });
 
-  // Idempotency: reuse an existing unrevoked token for this user rather than
-  // minting a new one on every broker call. The broker is expected to cache
-  // the returned token and only re-register on 401.
+  // At most one active "project-pilot" token per user. Hash-at-rest means
+  // the raw value of an existing token can no longer be recovered, so a
+  // repeat call revokes it and issues a fresh one instead of returning the
+  // same value again (see file-level comment above).
   const activeToken = await prisma.apiToken.findFirst({
     where: { userId: user.id, revokedAt: null, name: "project-pilot" },
     orderBy: { createdAt: "desc" },
   });
 
-  let apiToken: string;
   if (activeToken) {
-    apiToken = activeToken.token;
-  } else {
-    apiToken = generateApiToken();
-    await prisma.apiToken.create({
-      data: {
-        token: apiToken,
-        name: "project-pilot",
-        userId: user.id,
-      },
+    await prisma.apiToken.update({
+      where: { id: activeToken.id },
+      data: { revokedAt: new Date() },
     });
   }
+  const { raw: apiToken } = await createApiToken(prisma, user.id, "project-pilot");
 
   return NextResponse.json({
     apiToken,

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -34,7 +34,7 @@ export async function GET() {
     tokens: user.apiTokens.map((t) => ({
       id: t.id,
       name: t.name,
-      token: t.token,
+      tokenPrefix: t.tokenPrefix,
       lastUsedAt: t.lastUsedAt,
       createdAt: t.createdAt,
     })),

--- a/app/api/dashboard/tokens/route.ts
+++ b/app/api/dashboard/tokens/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
-import { prisma, generateApiToken } from "@/lib/db";
+import { prisma, createApiToken } from "@/lib/db";
 
 export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -17,23 +17,18 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Token name is required" }, { status: 400 });
     }
 
-    const token = generateApiToken();
-
-    const apiToken = await prisma.apiToken.create({
-      data: {
-        token,
-        name: name.trim(),
-        userId: session.user.id,
-      },
-    });
+    // The raw token is returned here and ONLY here: it is never persisted
+    // (only its hash is), so this response body is the one and only time
+    // the caller can see it.
+    const { raw, record } = await createApiToken(prisma, session.user.id, name.trim());
 
     return NextResponse.json({
       ok: true,
       token: {
-        id: apiToken.id,
-        name: apiToken.name,
-        token: apiToken.token,
-        createdAt: apiToken.createdAt,
+        id: record.id,
+        name: record.name,
+        token: raw,
+        createdAt: record.createdAt,
       },
     });
   } catch (error: unknown) {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,9 @@ const eslintConfig = [
       "build/**",
       "coverage/**",
       "next-env.d.ts",
+      // Standalone CJS ops script (no ts-node/tsx dependency by design —
+      // see its header comment), not part of the Next app's lint target.
+      "scripts/**",
     ],
   },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,10 +20,30 @@ const eslintConfig = [
       "build/**",
       "coverage/**",
       "next-env.d.ts",
-      // Standalone CJS ops script (no ts-node/tsx dependency by design —
-      // see its header comment), not part of the Next app's lint target.
-      "scripts/**",
     ],
+  },
+  {
+    // Standalone CJS ops scripts (no ts-node/tsx dependency by design — see
+    // scripts/backfill-api-token-hashes.js's header comment), run directly
+    // via `node`, not part of the Next app's browser/TS bundle. Scoped
+    // override rather than a blanket ignore, so they still get linted —
+    // just with Node globals and CommonJS `require` allowed.
+    files: ["scripts/**/*.js"],
+    languageOptions: {
+      sourceType: "commonjs",
+      globals: {
+        require: "readonly",
+        module: "writable",
+        exports: "writable",
+        process: "readonly",
+        console: "readonly",
+        __dirname: "readonly",
+        __filename: "readonly",
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
   },
 ];
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from "@prisma/client";
-import { randomBytes } from "crypto";
+import { createHmac, randomBytes } from "crypto";
 
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
 
@@ -20,10 +20,42 @@ export async function checkRateLimit(userId: string): Promise<{ allowed: boolean
   return { allowed: used < RATE_LIMIT_PER_DAY, used };
 }
 
+// API tokens are hashed at rest (keyed SHA-256 / HMAC-SHA256) rather than
+// stored in plaintext. A keyed hash keeps token lookup a plain unique-index
+// equality check (`WHERE tokenHash = ?`), which a per-row bcrypt/argon2
+// compare cannot offer without iterating every active token.
+//
+// The HMAC key defaults to NEXTAUTH_SECRET, which is already a required app
+// secret, so existing deployments need no new config. Set
+// API_TOKEN_HASH_SECRET to use a dedicated key that can rotate independently
+// of the session secret (rotating either one invalidates every issued API
+// token, since the hash can no longer be reproduced — same blast radius as
+// NextAuth session-secret rotation already has today).
+function getTokenHashSecret(): string {
+  const secret = process.env.API_TOKEN_HASH_SECRET || process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error(
+      "API_TOKEN_HASH_SECRET (or NEXTAUTH_SECRET) must be set to hash/verify API tokens"
+    );
+  }
+  return secret;
+}
+
+export function hashApiToken(rawToken: string): string {
+  return createHmac("sha256", getTokenHashSecret()).update(rawToken).digest("hex");
+}
+
+// Non-secret display hint for the dashboard's masked token list, e.g.
+// "pf_ab12cd34". Long enough to tell tokens apart, short enough to leave the
+// ~26 remaining random bytes of the secret unguessable.
+export function tokenPrefixOf(rawToken: string): string {
+  return rawToken.slice(0, 10);
+}
+
 export async function validateApiToken(token: string) {
   if (!token.startsWith("pf_")) return null;
   const record = await prisma.apiToken.findUnique({
-    where: { token },
+    where: { tokenHash: hashApiToken(token) },
     include: { user: true },
   });
   if (!record || record.revokedAt) return null;
@@ -37,4 +69,34 @@ export async function validateApiToken(token: string) {
 
 export function generateApiToken(): string {
   return `pf_${randomBytes(24).toString("base64url")}`;
+}
+
+/**
+ * Creates a new API token row and returns the one and only time the raw
+ * secret is available: the caller must hand `raw` back to the end user
+ * immediately (dashboard "show once" UI, or the register-from-project-pilot
+ * broker response) and never persist it — it cannot be recovered from the
+ * DB afterwards, only re-verified via hashApiToken().
+ *
+ * Takes the Prisma client explicitly (rather than closing over the module's
+ * own `prisma` export) so callers that test against a swapped-in mock
+ * client get that mock here too, instead of this function silently talking
+ * to the real database underneath the mock. Only requires an `apiToken.create`
+ * method (not the full PrismaClient shape) so a minimal test double works.
+ */
+export async function createApiToken(
+  client: { apiToken: Pick<PrismaClient["apiToken"], "create"> },
+  userId: string,
+  name: string
+) {
+  const raw = generateApiToken();
+  const record = await client.apiToken.create({
+    data: {
+      tokenHash: hashApiToken(raw),
+      tokenPrefix: tokenPrefixOf(raw),
+      name,
+      userId,
+    },
+  });
+  return { raw, record };
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -46,8 +46,10 @@ export function hashApiToken(rawToken: string): string {
 }
 
 // Non-secret display hint for the dashboard's masked token list, e.g.
-// "pf_ab12cd34". Long enough to tell tokens apart, short enough to leave the
-// ~26 remaining random bytes of the secret unguessable.
+// "pf_ab12cd3" (10 chars: the "pf_" prefix + 7 of the 32 base64url chars
+// generateApiToken() produces from its 24 random bytes). Long enough to
+// tell tokens apart, short enough to leave the ~25 remaining base64url
+// characters of the secret (~150 bits) unguessable.
 export function tokenPrefixOf(rawToken: string): string {
   return rawToken.slice(0, 10);
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,7 +29,14 @@ model User {
 
 model ApiToken {
   id          String     @id @default(cuid())
-  token       String     @unique
+  // Keyed-SHA256 (HMAC) digest of the raw token, hex-encoded. The raw value
+  // is shown to the user exactly once at creation and never persisted; auth
+  // re-hashes the presented token and looks it up by this unique index. See
+  // hashApiToken() in lib/db.ts.
+  tokenHash   String     @unique
+  // Non-secret display hint (first chars of the raw token, e.g. "pf_ab12cd")
+  // so the dashboard can show a masked identifier without the full secret.
+  tokenPrefix String
   name        String
   userId      String
   user        User       @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/scripts/backfill-api-token-hashes.js
+++ b/scripts/backfill-api-token-hashes.js
@@ -1,107 +1,259 @@
 #!/usr/bin/env node
 /**
- * One-time data migration: hashes existing plaintext ApiToken.token values
- * in place, ahead of deploying the schema/code that removes the plaintext
- * `token` column (see the apiTokens-hash-at-rest fix). Recommended approach
- * over invalidate+re-issue for the general ApiToken population: the
- * plaintext is still present in the DB at migration time, so no user needs
- * to be re-issued a new token / no CI or agent integration gets locked out.
+ * Two-phase (expand/contract) data migration: hashes existing plaintext
+ * ApiToken.token values in place, ahead of dropping the plaintext `token`
+ * column (see the apiTokens-hash-at-rest fix). Chosen over invalidate+
+ * re-issue for the general ApiToken population: the plaintext is still
+ * present in the DB at migration time, so no user/agent integration needs
+ * to be re-issued a new token or gets locked out.
  *
- * This project manages its schema via `prisma db push`, not
- * `prisma migrate` (see docs/ways-of-working.md) — there is no SQL
- * migration file that could carry a data transform, and SQLite has no
- * built-in HMAC/SHA-256 function to do the hashing inside SQL anyway. This
- * script is the out-of-band equivalent: plain Node + raw SQL, so it has no
- * dependency on `prisma generate` having already run against the new
- * schema, and needs no extra devDependency (no ts-node/tsx) to execute.
+ * This project manages its schema via `prisma db push`, not `prisma
+ * migrate` (see docs/ways-of-working.md) — there is no SQL migration file
+ * that could carry a data transform, and SQLite has no built-in HMAC/
+ * SHA-256 function to do the hashing inside SQL anyway. This script is the
+ * out-of-band equivalent: plain Node + raw SQL, so it has no dependency on
+ * `prisma generate` having already run against the new schema, and needs no
+ * extra devDependency (no ts-node/tsx) to execute.
  *
- * Order of operations for a real deploy:
- *   1. node scripts/backfill-api-token-hashes.js   (this script; idempotent
- *      — safe to re-run; skips rows that already have a tokenHash, and
- *      no-ops entirely once the `token` column is gone)
- *   2. deploy the new app code, then `npx prisma db push`
+ * WHY TWO PHASES: a single-shot script that backfills AND drops the `token`
+ * column in one run is only safe to execute while nothing still relies on
+ * `token`. This project's deploy runs `npx prisma db push --skip-generate`
+ * (Dockerfile CMD) with NO `--accept-data-loss`, and prisma/schema.prisma no
+ * longer declares `token` at all, so — verified locally, see below — `db
+ * push` REFUSES outright (exits non-zero, container fails to start) if
+ * `token` still holds data when it runs. That means contract cannot be a
+ * lazy "run it sometime after the new code has been live" step: it has to
+ * run in the same cutover as the deploy, strictly between stopping the OLD
+ * container (which still reads/writes `token`, so dropping it while that
+ * code is live would break every token-authenticated request) and starting
+ * the NEW one (whose own `db push` needs `token` already gone to succeed).
+ * Splitting into expand (additive, safe for days/weeks alongside the OLD
+ * code — do this well ahead of time, no downtime) and contract (destructive,
+ * only safe in that cutover window) makes that one required ordering
+ * explicit instead of leaving it implicit in a single script.
+ *
+ * Runbook for a real deploy:
+ *   1. node scripts/backfill-api-token-hashes.js            (expand; run
+ *      anytime before the deploy, no downtime — purely additive, the OLD
+ *      code keeps working against `token` untouched)
+ *   2. Stop the OLD container (brief downtime — the same restart window
+ *      `docker compose up -d --build` already causes for this project;
+ *      not a new downtime requirement).
+ *   3. node scripts/backfill-api-token-hashes.js --contract  (contract;
+ *      run now, with the OLD code stopped and the NEW code not yet
+ *      started — drops `token` and its legacy unique index for good)
+ *   4. Start the NEW container. Its own `npx prisma db push` now sees
+ *      `token` already gone and is a clean no-op.
+ * Both phases are idempotent — safe to re-run, and each is a no-op once its
+ * work is already done (including out of order: contract before expand
+ * ever ran is treated as "nothing to contract yet" rather than an error, as
+ * long as there's no plaintext `token` column to be destructive about).
+ *
+ * VERIFIED LOCALLY (SQLite, prisma 5.22.0; not run against any prod/real DB
+ * — see task rules): seeded a DB on the pre-fix schema with plaintext
+ * ApiToken rows, ran expand, confirmed tokenHash/tokenPrefix correctly
+ * populated while `token` and its data were untouched. Ran `prisma db push`
+ * (the new, token-less schema) against that intermediate expand-only state
+ * and confirmed it REFUSES with a data-loss error ("still contains N
+ * non-null values") rather than silently dropping data — this is what
+ * drove the corrected runbook above. Then ran contract, confirmed `token`
+ * and its index were dropped and all data preserved under
+ * tokenHash/tokenPrefix (still nullable at the raw-SQL level from the
+ * ADD COLUMN, unlike a fresh push's `NOT NULL`), and ran `prisma db push`
+ * again: clean no-op, no data-loss prompt, and this version of `db push`
+ * does not attempt to tighten that nullable-vs-schema's-NOT-NULL gap into a
+ * migration. Also verified idempotency (re-running expand after contract,
+ * and re-running contract twice, are both no-ops) and the fail-loud path
+ * (seeded a row with an empty-string token; expand hashed the good row,
+ * then reported the bad one and exited 1 without creating the unique
+ * index; after removing the bad row, a re-run completed cleanly).
  *
  * The hashing here MUST stay in lockstep with hashApiToken()/tokenPrefixOf()
  * in lib/db.ts (HMAC-SHA256 hex digest, first 10 chars as the prefix). If
  * those change, update this script to match, or verification will fail for
- * every token that predates the change.
+ * every token that predates the change. tests/unit/hash-parity.test.ts
+ * asserts the two stay identical for a fixed input.
  *
  * Usage:
  *   DATABASE_URL=file:./db/project-forge.db \
  *   API_TOKEN_HASH_SECRET=... (or rely on NEXTAUTH_SECRET) \
- *   node scripts/backfill-api-token-hashes.js
+ *   node scripts/backfill-api-token-hashes.js [--contract]
  */
 const { PrismaClient } = require("@prisma/client");
 const { createHmac } = require("crypto");
 
-const secret = process.env.API_TOKEN_HASH_SECRET || process.env.NEXTAUTH_SECRET;
-if (!secret) {
-  console.error(
-    "API_TOKEN_HASH_SECRET (or NEXTAUTH_SECRET) must be set — refusing to hash tokens with no key."
-  );
-  process.exit(1);
+// Lazy (not computed at module load) so requiring this file for its pure
+// helpers — e.g. the hash-parity test — never fails just because the
+// importing process hasn't set a hash secret.
+function getSecret() {
+  const secret = process.env.API_TOKEN_HASH_SECRET || process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error(
+      "API_TOKEN_HASH_SECRET (or NEXTAUTH_SECRET) must be set — refusing to hash tokens with no key."
+    );
+  }
+  return secret;
 }
 
 function hashApiToken(rawToken) {
-  return createHmac("sha256", secret).update(rawToken).digest("hex");
+  return createHmac("sha256", getSecret()).update(rawToken).digest("hex");
 }
 
 function tokenPrefixOf(rawToken) {
   return rawToken.slice(0, 10);
 }
 
+async function getColumnNames(prisma) {
+  const columns = await prisma.$queryRawUnsafe('PRAGMA table_info("ApiToken")');
+  return new Set(columns.map((c) => c.name));
+}
+
+async function countNullTokenHash(prisma) {
+  const rows = await prisma.$queryRawUnsafe(
+    'SELECT COUNT(*) as c FROM "ApiToken" WHERE tokenHash IS NULL'
+  );
+  return Number(rows[0].c);
+}
+
+/**
+ * Additive only: add tokenHash/tokenPrefix (nullable, so this never
+ * conflicts with existing rows) and backfill them from the still-present
+ * plaintext `token` column. Never touches `token` itself.
+ */
+async function runExpand(prisma) {
+  const columnNames = await getColumnNames(prisma);
+
+  if (!columnNames.has("token")) {
+    console.log(
+      "No plaintext `token` column on ApiToken — nothing to expand " +
+        "(already contracted, or a fresh install that never had one)."
+    );
+    return;
+  }
+
+  if (!columnNames.has("tokenHash")) {
+    await prisma.$executeRawUnsafe('ALTER TABLE "ApiToken" ADD COLUMN "tokenHash" TEXT');
+  }
+  if (!columnNames.has("tokenPrefix")) {
+    await prisma.$executeRawUnsafe('ALTER TABLE "ApiToken" ADD COLUMN "tokenPrefix" TEXT');
+  }
+
+  const rows = await prisma.$queryRawUnsafe(
+    'SELECT id, token FROM "ApiToken" WHERE tokenHash IS NULL'
+  );
+
+  let skippedNullToken = 0;
+  console.log(`Backfilling ${rows.length} token(s)...`);
+  for (const row of rows) {
+    if (!row.token) {
+      skippedNullToken++;
+      continue;
+    }
+    await prisma.$executeRawUnsafe(
+      'UPDATE "ApiToken" SET tokenHash = ?, tokenPrefix = ? WHERE id = ?',
+      hashApiToken(row.token),
+      tokenPrefixOf(row.token),
+      row.id
+    );
+  }
+
+  if (skippedNullToken > 0) {
+    console.error(
+      `ERROR: ${skippedNullToken} ApiToken row(s) have no plaintext token value ` +
+        "and could not be hashed. Fix or hard-delete these rows manually, then " +
+        "re-run expand. Refusing to create the tokenHash unique index while any " +
+        "row would be left without a hash — contract must not run until this is 0."
+    );
+    process.exit(1);
+  }
+
+  // Fail loud rather than silently proceed: re-check from scratch (not just
+  // "skippedNullToken === 0" above, which only covers rows seen in *this*
+  // run) before creating the unique index that contract's final schema
+  // relies on being fully populated.
+  const remaining = await countNullTokenHash(prisma);
+  if (remaining > 0) {
+    console.error(
+      `ERROR: ${remaining} ApiToken row(s) still have no tokenHash after backfill — ` +
+        "refusing to create the unique index. Investigate before re-running."
+    );
+    process.exit(1);
+  }
+
+  await prisma.$executeRawUnsafe(
+    'CREATE UNIQUE INDEX IF NOT EXISTS "ApiToken_tokenHash_key" ON "ApiToken"("tokenHash")'
+  );
+
+  console.log(
+    "Expand done. tokenHash/tokenPrefix populated for all rows; `token` column " +
+      "untouched, old code keeps working. At deploy time: stop the old " +
+      "container, run this script again with --contract, then start the new one."
+  );
+}
+
+/**
+ * Destructive: drops the legacy `token` column and its unique index. Only
+ * safe once the new app code (reading tokenHash, not token) is live —
+ * see the file header runbook.
+ */
+async function runContract(prisma) {
+  const columnNames = await getColumnNames(prisma);
+
+  if (!columnNames.has("token")) {
+    console.log("No plaintext `token` column on ApiToken — already contracted.");
+    return;
+  }
+
+  if (!columnNames.has("tokenHash")) {
+    console.error(
+      "ERROR: no tokenHash column found. Run expand (no --contract flag) first."
+    );
+    process.exit(1);
+  }
+
+  const remaining = await countNullTokenHash(prisma);
+  if (remaining > 0) {
+    console.error(
+      `ERROR: ${remaining} ApiToken row(s) still have no tokenHash. Refusing to ` +
+        "drop `token` — re-run expand until it reports 0 remaining first."
+    );
+    process.exit(1);
+  }
+
+  // Defensive: (re-)create the index in case expand's own creation was
+  // somehow skipped; idempotent either way.
+  await prisma.$executeRawUnsafe(
+    'CREATE UNIQUE INDEX IF NOT EXISTS "ApiToken_tokenHash_key" ON "ApiToken"("tokenHash")'
+  );
+  await prisma.$executeRawUnsafe('DROP INDEX IF EXISTS "ApiToken_token_key"');
+  await prisma.$executeRawUnsafe('ALTER TABLE "ApiToken" DROP COLUMN "token"');
+
+  console.log("Contract done. `token` column and its legacy index are gone.");
+}
+
 async function main() {
+  const contract = process.argv.includes("--contract");
   const prisma = new PrismaClient();
   try {
-    const columns = await prisma.$queryRawUnsafe('PRAGMA table_info("ApiToken")');
-    const columnNames = new Set(columns.map((c) => c.name));
-
-    if (!columnNames.has("token")) {
-      console.log(
-        "No plaintext `token` column on ApiToken — nothing to backfill (already migrated?)."
-      );
-      return;
+    if (contract) {
+      await runContract(prisma);
+    } else {
+      await runExpand(prisma);
     }
-
-    if (!columnNames.has("tokenHash")) {
-      await prisma.$executeRawUnsafe('ALTER TABLE "ApiToken" ADD COLUMN "tokenHash" TEXT');
-    }
-    if (!columnNames.has("tokenPrefix")) {
-      await prisma.$executeRawUnsafe('ALTER TABLE "ApiToken" ADD COLUMN "tokenPrefix" TEXT');
-    }
-
-    const rows = await prisma.$queryRawUnsafe(
-      'SELECT id, token FROM "ApiToken" WHERE tokenHash IS NULL'
-    );
-
-    console.log(`Backfilling ${rows.length} token(s)...`);
-    for (const row of rows) {
-      if (!row.token) continue;
-      await prisma.$executeRawUnsafe(
-        'UPDATE "ApiToken" SET tokenHash = ?, tokenPrefix = ? WHERE id = ?',
-        hashApiToken(row.token),
-        tokenPrefixOf(row.token),
-        row.id
-      );
-    }
-
-    // Finalize the schema to match prisma/schema.prisma exactly, so the
-    // `prisma db push` that follows sees no destructive diff and no-ops.
-    await prisma.$executeRawUnsafe(
-      'CREATE UNIQUE INDEX IF NOT EXISTS "ApiToken_tokenHash_key" ON "ApiToken"("tokenHash")'
-    );
-    await prisma.$executeRawUnsafe('DROP INDEX IF EXISTS "ApiToken_token_key"');
-    await prisma.$executeRawUnsafe('ALTER TABLE "ApiToken" DROP COLUMN "token"');
-
-    console.log(
-      "Done. `token` column dropped; tokenHash/tokenPrefix populated for all rows."
-    );
   } finally {
     await prisma.$disconnect();
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+module.exports = { hashApiToken, tokenPrefixOf };
+
+// Only run as a side effect when executed directly (`node
+// scripts/backfill-api-token-hashes.js`), not when required by a test that
+// just wants the pure hashApiToken/tokenPrefixOf helpers for a parity check
+// — requiring this file must not open a DB connection.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/backfill-api-token-hashes.js
+++ b/scripts/backfill-api-token-hashes.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * One-time data migration: hashes existing plaintext ApiToken.token values
+ * in place, ahead of deploying the schema/code that removes the plaintext
+ * `token` column (see the apiTokens-hash-at-rest fix). Recommended approach
+ * over invalidate+re-issue for the general ApiToken population: the
+ * plaintext is still present in the DB at migration time, so no user needs
+ * to be re-issued a new token / no CI or agent integration gets locked out.
+ *
+ * This project manages its schema via `prisma db push`, not
+ * `prisma migrate` (see docs/ways-of-working.md) — there is no SQL
+ * migration file that could carry a data transform, and SQLite has no
+ * built-in HMAC/SHA-256 function to do the hashing inside SQL anyway. This
+ * script is the out-of-band equivalent: plain Node + raw SQL, so it has no
+ * dependency on `prisma generate` having already run against the new
+ * schema, and needs no extra devDependency (no ts-node/tsx) to execute.
+ *
+ * Order of operations for a real deploy:
+ *   1. node scripts/backfill-api-token-hashes.js   (this script; idempotent
+ *      — safe to re-run; skips rows that already have a tokenHash, and
+ *      no-ops entirely once the `token` column is gone)
+ *   2. deploy the new app code, then `npx prisma db push`
+ *
+ * The hashing here MUST stay in lockstep with hashApiToken()/tokenPrefixOf()
+ * in lib/db.ts (HMAC-SHA256 hex digest, first 10 chars as the prefix). If
+ * those change, update this script to match, or verification will fail for
+ * every token that predates the change.
+ *
+ * Usage:
+ *   DATABASE_URL=file:./db/project-forge.db \
+ *   API_TOKEN_HASH_SECRET=... (or rely on NEXTAUTH_SECRET) \
+ *   node scripts/backfill-api-token-hashes.js
+ */
+const { PrismaClient } = require("@prisma/client");
+const { createHmac } = require("crypto");
+
+const secret = process.env.API_TOKEN_HASH_SECRET || process.env.NEXTAUTH_SECRET;
+if (!secret) {
+  console.error(
+    "API_TOKEN_HASH_SECRET (or NEXTAUTH_SECRET) must be set — refusing to hash tokens with no key."
+  );
+  process.exit(1);
+}
+
+function hashApiToken(rawToken) {
+  return createHmac("sha256", secret).update(rawToken).digest("hex");
+}
+
+function tokenPrefixOf(rawToken) {
+  return rawToken.slice(0, 10);
+}
+
+async function main() {
+  const prisma = new PrismaClient();
+  try {
+    const columns = await prisma.$queryRawUnsafe('PRAGMA table_info("ApiToken")');
+    const columnNames = new Set(columns.map((c) => c.name));
+
+    if (!columnNames.has("token")) {
+      console.log(
+        "No plaintext `token` column on ApiToken — nothing to backfill (already migrated?)."
+      );
+      return;
+    }
+
+    if (!columnNames.has("tokenHash")) {
+      await prisma.$executeRawUnsafe('ALTER TABLE "ApiToken" ADD COLUMN "tokenHash" TEXT');
+    }
+    if (!columnNames.has("tokenPrefix")) {
+      await prisma.$executeRawUnsafe('ALTER TABLE "ApiToken" ADD COLUMN "tokenPrefix" TEXT');
+    }
+
+    const rows = await prisma.$queryRawUnsafe(
+      'SELECT id, token FROM "ApiToken" WHERE tokenHash IS NULL'
+    );
+
+    console.log(`Backfilling ${rows.length} token(s)...`);
+    for (const row of rows) {
+      if (!row.token) continue;
+      await prisma.$executeRawUnsafe(
+        'UPDATE "ApiToken" SET tokenHash = ?, tokenPrefix = ? WHERE id = ?',
+        hashApiToken(row.token),
+        tokenPrefixOf(row.token),
+        row.id
+      );
+    }
+
+    // Finalize the schema to match prisma/schema.prisma exactly, so the
+    // `prisma db push` that follows sees no destructive diff and no-ops.
+    await prisma.$executeRawUnsafe(
+      'CREATE UNIQUE INDEX IF NOT EXISTS "ApiToken_tokenHash_key" ON "ApiToken"("tokenHash")'
+    );
+    await prisma.$executeRawUnsafe('DROP INDEX IF EXISTS "ApiToken_token_key"');
+    await prisma.$executeRawUnsafe('ALTER TABLE "ApiToken" DROP COLUMN "token"');
+
+    console.log(
+      "Done. `token` column dropped; tokenHash/tokenPrefix populated for all rows."
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-api-token-hashes.js
+++ b/scripts/backfill-api-token-hashes.js
@@ -28,21 +28,31 @@
  * code is live would break every token-authenticated request) and starting
  * the NEW one (whose own `db push` needs `token` already gone to succeed).
  * Splitting into expand (additive, safe for days/weeks alongside the OLD
- * code — do this well ahead of time, no downtime) and contract (destructive,
- * only safe in that cutover window) makes that one required ordering
- * explicit instead of leaving it implicit in a single script.
+ * code — do this well ahead of time) and contract (destructive, only safe
+ * in that cutover window) makes that one required ordering explicit
+ * instead of leaving it implicit in a single script.
  *
  * Runbook for a real deploy:
  *   1. node scripts/backfill-api-token-hashes.js            (expand; run
- *      anytime before the deploy, no downtime — purely additive, the OLD
- *      code keeps working against `token` untouched)
+ *      well ahead of the deploy — purely additive, the OLD code keeps
+ *      working against `token` untouched. NOTE: the OLD code is still
+ *      live and keeps minting/serving plaintext-only rows the whole time,
+ *      so this early run does NOT cover every row that will exist by
+ *      cutover — step 3 below does.)
  *   2. Stop the OLD container (brief downtime — the same restart window
  *      `docker compose up -d --build` already causes for this project;
  *      not a new downtime requirement).
- *   3. node scripts/backfill-api-token-hashes.js --contract  (contract;
- *      run now, with the OLD code stopped and the NEW code not yet
- *      started — drops `token` and its legacy unique index for good)
- *   4. Start the NEW container. Its own `npx prisma db push` now sees
+ *   3. node scripts/backfill-api-token-hashes.js            (expand AGAIN,
+ *      now that the OLD code is stopped — REQUIRED, not optional: this is
+ *      what actually hashes any tokens created/rotated between step 1 and
+ *      step 2. Cheap and idempotent — a no-op if nothing changed. Confirm
+ *      its output before proceeding: it must NOT hit the fail-loud "N
+ *      row(s) still have no tokenHash" error. If it does, contract will
+ *      refuse too — resolve those rows first.)
+ *   4. node scripts/backfill-api-token-hashes.js --contract  (contract;
+ *      safe now that step 3 has confirmed 0 rows remain unhashed — drops
+ *      `token` and its legacy unique index for good)
+ *   5. Start the NEW container. Its own `npx prisma db push` now sees
  *      `token` already gone and is a clean no-op.
  * Both phases are idempotent — safe to re-run, and each is a no-op once its
  * work is already done (including out of order: contract before expand

--- a/tests/integration/backfill-api-token-hashes-script.test.ts
+++ b/tests/integration/backfill-api-token-hashes-script.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { PrismaClient } from "@prisma/client";
+
+/**
+ * Integration coverage for scripts/backfill-api-token-hashes.js's own
+ * control flow (expand / --contract / fail-loud), run as a real child
+ * process against a real (throwaway, file-based) SQLite DB — not mocked,
+ * since the whole point of this script is raw-SQL DDL/DML that a mocked
+ * Prisma client can't meaningfully exercise. This is the automated
+ * counterpart to the manual verification recorded in the script's own
+ * header comment (9 scenarios, run by hand during development).
+ *
+ * Each test builds its own scratch DB directly via raw SQL through the
+ * project's already-generated PrismaClient (never via `prisma db push` /
+ * `prisma generate` against a temp schema — that would regenerate the
+ * shared node_modules/@prisma/client the rest of the suite depends on).
+ */
+
+const SCRIPT_PATH = path.join(__dirname, "..", "..", "scripts", "backfill-api-token-hashes.js");
+const SECRET = "script-integration-test-secret";
+
+let tmpDir: string | undefined;
+
+afterEach(() => {
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  }
+});
+
+function newDbPath(): string {
+  tmpDir = mkdtempSync(path.join(tmpdir(), "pf-token-migration-"));
+  return path.join(tmpDir, "legacy.db");
+}
+
+/** Builds a scratch DB matching the pre-fix (plaintext `token` column) shape. */
+async function seedLegacyDb(
+  dbPath: string,
+  tokens: Array<{ id: string; token: string; name: string }>
+) {
+  const prisma = new PrismaClient({ datasources: { db: { url: `file:${dbPath}` } } });
+  try {
+    await prisma.$executeRawUnsafe(
+      'CREATE TABLE "User" ("id" TEXT NOT NULL PRIMARY KEY, "email" TEXT, ' +
+        '"createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, ' +
+        '"updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)'
+    );
+    await prisma.$executeRawUnsafe(
+      'CREATE TABLE "ApiToken" ("id" TEXT NOT NULL PRIMARY KEY, "token" TEXT NOT NULL, ' +
+        '"name" TEXT NOT NULL, "userId" TEXT NOT NULL, "revokedAt" DATETIME, ' +
+        '"lastUsedAt" DATETIME, "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, ' +
+        'FOREIGN KEY ("userId") REFERENCES "User" ("id"))'
+    );
+    await prisma.$executeRawUnsafe('CREATE UNIQUE INDEX "ApiToken_token_key" ON "ApiToken"("token")');
+    await prisma.$executeRawUnsafe(`INSERT INTO "User" (id, email) VALUES ('user-1', 'u@test.com')`);
+    for (const t of tokens) {
+      await prisma.$executeRawUnsafe(
+        'INSERT INTO "ApiToken" (id, token, name, userId) VALUES (?, ?, ?, ?)',
+        t.id,
+        t.token,
+        t.name,
+        "user-1"
+      );
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+function openRaw(dbPath: string): PrismaClient {
+  return new PrismaClient({ datasources: { db: { url: `file:${dbPath}` } } });
+}
+
+async function columnNames(prisma: PrismaClient): Promise<Set<string>> {
+  const cols = await prisma.$queryRawUnsafe<{ name: string }[]>('PRAGMA table_info("ApiToken")');
+  return new Set(cols.map((c) => c.name));
+}
+
+async function indexNames(prisma: PrismaClient): Promise<Set<string>> {
+  const rows = await prisma.$queryRawUnsafe<{ name: string }[]>(
+    `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='ApiToken'`
+  );
+  return new Set(rows.map((r) => r.name));
+}
+
+function runScript(dbPath: string, args: string[] = []) {
+  return execFileSync("node", [SCRIPT_PATH, ...args], {
+    env: { ...process.env, DATABASE_URL: `file:${dbPath}`, API_TOKEN_HASH_SECRET: SECRET },
+    encoding: "utf8",
+  });
+}
+
+describe("scripts/backfill-api-token-hashes.js (real SQLite child-process integration)", () => {
+  it("expand: hashes plaintext rows, populates tokenHash/tokenPrefix, and leaves `token` untouched", async () => {
+    const dbPath = newDbPath();
+    await seedLegacyDb(dbPath, [{ id: "tok-1", token: "pf_realplaintextrandomvalue1", name: "ci" }]);
+
+    const stdout = runScript(dbPath);
+    expect(stdout).toContain("Expand done");
+
+    const prisma = openRaw(dbPath);
+    try {
+      const cols = await columnNames(prisma);
+      expect(cols.has("token")).toBe(true);
+      expect(cols.has("tokenHash")).toBe(true);
+      expect(cols.has("tokenPrefix")).toBe(true);
+
+      const rows = await prisma.$queryRawUnsafe<
+        { id: string; token: string; tokenHash: string; tokenPrefix: string }[]
+      >('SELECT id, token, tokenHash, tokenPrefix FROM "ApiToken"');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].token).toBe("pf_realplaintextrandomvalue1");
+      expect(rows[0].tokenHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(rows[0].tokenPrefix).toBe("pf_realpla");
+
+      expect(await indexNames(prisma)).toContain("ApiToken_tokenHash_key");
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+
+  it("contract: drops `token` and its legacy index once expand has fully run", async () => {
+    const dbPath = newDbPath();
+    await seedLegacyDb(dbPath, [{ id: "tok-1", token: "pf_realplaintextrandomvalue1", name: "ci" }]);
+    runScript(dbPath);
+
+    const stdout = runScript(dbPath, ["--contract"]);
+    expect(stdout).toContain("Contract done");
+
+    const prisma = openRaw(dbPath);
+    try {
+      const cols = await columnNames(prisma);
+      expect(cols.has("token")).toBe(false);
+      expect(cols.has("tokenHash")).toBe(true);
+
+      const idx = await indexNames(prisma);
+      expect(idx.has("ApiToken_token_key")).toBe(false);
+      expect(idx.has("ApiToken_tokenHash_key")).toBe(true);
+
+      const rows = await prisma.$queryRawUnsafe<{ tokenHash: string }[]>(
+        'SELECT tokenHash FROM "ApiToken"'
+      );
+      expect(rows[0].tokenHash).toMatch(/^[0-9a-f]{64}$/);
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+
+  it("both phases are idempotent: re-running expand or contract after contract is a clean no-op", async () => {
+    const dbPath = newDbPath();
+    await seedLegacyDb(dbPath, [{ id: "tok-1", token: "pf_realplaintextrandomvalue1", name: "ci" }]);
+    runScript(dbPath);
+    runScript(dbPath, ["--contract"]);
+
+    const reExpand = runScript(dbPath);
+    expect(reExpand).toContain("nothing to expand");
+
+    const reContract = runScript(dbPath, ["--contract"]);
+    expect(reContract).toContain("already contracted");
+  });
+
+  it("contract refuses (exit 1) when expand hasn't populated tokenHash yet", async () => {
+    // A fresh legacy DB has no tokenHash column at all — contract must not
+    // attempt to drop `token` before expand has run at least once.
+    const dbPath = newDbPath();
+    await seedLegacyDb(dbPath, [{ id: "tok-1", token: "pf_realvalue", name: "ci" }]);
+
+    let threw = false;
+    let stderr = "";
+    try {
+      runScript(dbPath, ["--contract"]);
+    } catch (err) {
+      threw = true;
+      stderr = (err as { stderr?: string }).stderr ?? "";
+    }
+    expect(threw).toBe(true);
+    expect(stderr).toContain("Run expand");
+  });
+
+  it("fail-loud: a row with no plaintext token value blocks expand and the unique index is never created", async () => {
+    const dbPath = newDbPath();
+    await seedLegacyDb(dbPath, [
+      { id: "tok-good", token: "pf_realgoodvalue", name: "ci" },
+      { id: "tok-empty", token: "", name: "broken" },
+    ]);
+
+    let threw = false;
+    let stderr = "";
+    try {
+      runScript(dbPath);
+    } catch (err) {
+      threw = true;
+      stderr = (err as { stderr?: string }).stderr ?? "";
+    }
+    expect(threw).toBe(true);
+    expect(stderr).toContain("have no plaintext token value");
+
+    const prisma = openRaw(dbPath);
+    try {
+      // The good row is still hashed even though the run overall failed...
+      const rows = await prisma.$queryRawUnsafe<{ id: string; tokenHash: string | null }[]>(
+        'SELECT id, tokenHash FROM "ApiToken"'
+      );
+      const good = rows.find((r) => r.id === "tok-good");
+      expect(good?.tokenHash).toMatch(/^[0-9a-f]{64}$/);
+      // ...but the unique index must NOT have been created while any row
+      // is left without a hash.
+      expect(await indexNames(prisma)).not.toContain("ApiToken_tokenHash_key");
+    } finally {
+      await prisma.$disconnect();
+    }
+
+    // Fixed after removing the bad row: a clean re-run succeeds.
+    const fixDb = openRaw(dbPath);
+    try {
+      await fixDb.$executeRawUnsafe('DELETE FROM "ApiToken" WHERE id = ?', "tok-empty");
+    } finally {
+      await fixDb.$disconnect();
+    }
+    const stdout = runScript(dbPath);
+    expect(stdout).toContain("Expand done");
+  });
+});

--- a/tests/integration/dashboard-route.test.ts
+++ b/tests/integration/dashboard-route.test.ts
@@ -120,6 +120,13 @@ describe("GET /api/dashboard", () => {
           name: "ci",
           tokenHash: "deadbeef_hash_value_never_returned",
           tokenPrefix: "pf_abc123",
+          // Sentinel raw value: if the route regressed to spreading the row
+          // (or re-added `token: t.token`), this is what would leak. Kept
+          // on the fixture so the "never leaks" assertions below actually
+          // have something to catch — a fixture with no raw value at all
+          // would let `t.token` silently resolve to `undefined` and pass
+          // regardless of whether the route re-introduces the field.
+          token: "pf_RAW_SHOULD_NEVER_LEAK",
           lastUsedAt,
           createdAt,
         },
@@ -149,10 +156,14 @@ describe("GET /api/dashboard", () => {
       },
     ]);
     // Only a non-secret prefix ever leaves this route — no tokenHash, no
-    // full/raw token value anywhere in the response.
+    // full/raw token value anywhere in the response. These assertions
+    // would fail if the route regressed to `token: t.token` or a bare
+    // spread of the DB row, because the fixture carries a real sentinel
+    // value for both fields (not `undefined`).
     expect(body.tokens[0].token).toBeUndefined();
     expect(body.tokens[0].tokenHash).toBeUndefined();
     expect(JSON.stringify(body)).not.toContain("deadbeef_hash_value_never_returned");
+    expect(JSON.stringify(body)).not.toContain("pf_RAW_SHOULD_NEVER_LEAK");
   });
 
   it("200 happy path returns githubPatConnected: false when the user has no PAT set", async () => {

--- a/tests/integration/dashboard-route.test.ts
+++ b/tests/integration/dashboard-route.test.ts
@@ -9,6 +9,10 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
  * The settings page, which pre-fills/edits the raw token, reads it from the
  * dedicated GET /api/dashboard/pat endpoint (see dashboard-token-management.test.ts).
  * These tests assert the raw PAT is absent and the boolean is present.
+ *
+ * Same treatment for API tokens: apiTokens.token is hashed at rest (never
+ * queried/selected here in the first place), and this route only ever
+ * returns the non-secret `tokenPrefix` display hint, never a raw token.
  */
 
 vi.mock("next-auth", () => ({
@@ -114,7 +118,8 @@ describe("GET /api/dashboard", () => {
         {
           id: "tok-1",
           name: "ci",
-          token: "pf_abc123",
+          tokenHash: "deadbeef_hash_value_never_returned",
+          tokenPrefix: "pf_abc123",
           lastUsedAt,
           createdAt,
         },
@@ -138,11 +143,16 @@ describe("GET /api/dashboard", () => {
       {
         id: "tok-1",
         name: "ci",
-        token: "pf_abc123",
+        tokenPrefix: "pf_abc123",
         lastUsedAt: lastUsedAt.toISOString(),
         createdAt: createdAt.toISOString(),
       },
     ]);
+    // Only a non-secret prefix ever leaves this route — no tokenHash, no
+    // full/raw token value anywhere in the response.
+    expect(body.tokens[0].token).toBeUndefined();
+    expect(body.tokens[0].tokenHash).toBeUndefined();
+    expect(JSON.stringify(body)).not.toContain("deadbeef_hash_value_never_returned");
   });
 
   it("200 happy path returns githubPatConnected: false when the user has no PAT set", async () => {

--- a/tests/integration/dashboard-token-management.test.ts
+++ b/tests/integration/dashboard-token-management.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, beforeAll } from "vitest";
 import { NextRequest } from "next/server";
 
 /**
  * Integration tests for the three dashboard API routes that manage tokens and
  * the GitHub PAT. No live DB or session required — all dependencies are mocked.
+ *
+ * NOTE on mocking: `@/lib/db` is mocked module-wide with `prisma` swapped for
+ * a fake, while other exports (hashApiToken, generateApiToken, createApiToken)
+ * stay real via vi.importActual. createApiToken() takes the Prisma client as
+ * an explicit parameter (rather than closing over lib/db's own singleton)
+ * specifically so it picks up this test's fake `prisma`, not a real one.
  */
 
 vi.mock("next-auth", () => ({
@@ -66,6 +72,10 @@ const AUTHED_SESSION = { user: { id: "user-1", email: "u@test.com" } };
 // POST /api/dashboard/tokens  (create token)
 // ---------------------------------------------------------------------------
 describe("POST /api/dashboard/tokens", () => {
+  beforeAll(() => {
+    process.env.NEXTAUTH_SECRET = "test-hash-secret";
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -95,14 +105,16 @@ describe("POST /api/dashboard/tokens", () => {
 
   it("200 on success and returned token starts with pf_", async () => {
     mGetSession.mockResolvedValue(AUTHED_SESSION as never);
-    apiToken.create.mockImplementation(({ data }: { data: { token: string; name: string; userId: string } }) =>
-      Promise.resolve({
-        id: "tok-new",
-        token: data.token,
-        name: data.name,
-        userId: data.userId,
-        createdAt: new Date(),
-      })
+    apiToken.create.mockImplementation(
+      ({ data }: { data: { tokenHash: string; tokenPrefix: string; name: string; userId: string } }) =>
+        Promise.resolve({
+          id: "tok-new",
+          tokenHash: data.tokenHash,
+          tokenPrefix: data.tokenPrefix,
+          name: data.name,
+          userId: data.userId,
+          createdAt: new Date(),
+        })
     );
 
     const res = await createToken(jsonReq("http://test/api/dashboard/tokens", { name: "ci-token" }));
@@ -111,23 +123,34 @@ describe("POST /api/dashboard/tokens", () => {
     expect(body.ok).toBe(true);
     expect(body.token.token).toMatch(/^pf_/);
     expect(body.token.name).toBe("ci-token");
+    // The response must carry the raw token, never a hash or the field name
+    // the DB stores it under.
+    expect(body.token.tokenHash).toBeUndefined();
   });
 
-  it("creates the token with userId === session.user.id", async () => {
+  it("persists only the hash + prefix in prisma.apiToken.create, never the raw token", async () => {
     mGetSession.mockResolvedValue(AUTHED_SESSION as never);
     apiToken.create.mockResolvedValue({
       id: "tok-x",
-      token: "pf_test",
+      tokenHash: "irrelevant-in-this-assertion",
+      tokenPrefix: "pf_test123",
       name: "my-token",
       userId: "user-1",
       createdAt: new Date(),
     });
 
-    await createToken(jsonReq("http://test/api/dashboard/tokens", { name: "my-token" }));
+    const res = await createToken(jsonReq("http://test/api/dashboard/tokens", { name: "my-token" }));
+    const body = await res.json();
 
     expect(apiToken.create).toHaveBeenCalledTimes(1);
     const createArg = apiToken.create.mock.calls[0][0];
     expect(createArg.data.userId).toBe("user-1");
+    expect(createArg.data).not.toHaveProperty("token");
+    expect(createArg.data.tokenHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(createArg.data.tokenPrefix).toBe(body.token.token.slice(0, 10));
+    // The exact raw value returned to the caller must never itself appear
+    // in what got sent to prisma.apiToken.create.
+    expect(JSON.stringify(createArg)).not.toContain(body.token.token);
   });
 });
 
@@ -186,7 +209,8 @@ describe("DELETE /api/dashboard/tokens/[id]", () => {
     mGetSession.mockResolvedValue(AUTHED_SESSION as never);
     apiToken.findFirst.mockResolvedValue({
       id: "tok-mine",
-      token: "pf_mine",
+      tokenHash: "mocked-hash-value",
+      tokenPrefix: "pf_mine123",
       userId: "user-1",
       revokedAt: null,
     });

--- a/tests/integration/register-from-project-pilot.test.ts
+++ b/tests/integration/register-from-project-pilot.test.ts
@@ -3,12 +3,21 @@ import { describe, expect, it, vi, beforeEach, beforeAll } from "vitest";
 // Mock the Prisma client before importing the route.
 vi.mock("@/lib/db", async () => {
   const actual = await vi.importActual<typeof import("@/lib/db")>("@/lib/db");
+  const mockPrisma: {
+    user: { findUnique: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> };
+    apiToken: { create: ReturnType<typeof vi.fn>; updateMany: ReturnType<typeof vi.fn> };
+    $transaction: ReturnType<typeof vi.fn>;
+  } = {
+    user: { findUnique: vi.fn(), update: vi.fn(), create: vi.fn() },
+    apiToken: { create: vi.fn(), updateMany: vi.fn() },
+    // Interactive-transaction mock: just runs the callback against the same
+    // mocked client, mirroring Prisma's real $transaction(async (tx) => ...)
+    // shape closely enough for these unit-style tests.
+    $transaction: vi.fn((fn: (tx: typeof mockPrisma) => unknown) => fn(mockPrisma)),
+  };
   return {
     ...actual,
-    prisma: {
-      user: { findUnique: vi.fn(), update: vi.fn(), create: vi.fn() },
-      apiToken: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
-    },
+    prisma: mockPrisma,
   };
 });
 
@@ -32,9 +41,8 @@ const user = prisma.user as unknown as {
   create: ReturnType<typeof vi.fn>;
 };
 const apiToken = prisma.apiToken as unknown as {
-  findFirst: ReturnType<typeof vi.fn>;
   create: ReturnType<typeof vi.fn>;
-  update: ReturnType<typeof vi.fn>;
+  updateMany: ReturnType<typeof vi.fn>;
 };
 
 function makeReq(body: unknown): NextRequest {
@@ -101,7 +109,6 @@ describe("POST /api/auth/register-from-project-pilot", () => {
     });
     user.findUnique.mockResolvedValue(null);
     user.create.mockResolvedValue({ id: "user-1" });
-    apiToken.findFirst.mockResolvedValue(null);
     apiToken.create.mockResolvedValue({});
 
     const res = await POST(makeReq({ githubAccessToken: "valid", githubLogin: "newbie" }));
@@ -157,13 +164,7 @@ describe("POST /api/auth/register-from-project-pilot", () => {
       email: null,
     });
     user.update.mockResolvedValue({ id: "user-existing" });
-    apiToken.findFirst.mockResolvedValue({
-      id: "tok-existing",
-      tokenHash: "hash-of-a-token-we-no-longer-have-the-raw-value-for",
-      userId: "user-existing",
-      revokedAt: null,
-    });
-    apiToken.update.mockResolvedValue({ id: "tok-existing", revokedAt: new Date() });
+    apiToken.updateMany.mockResolvedValue({ count: 1 });
     apiToken.create.mockResolvedValue({});
 
     const res = await POST(makeReq({ githubAccessToken: "valid" }));
@@ -173,10 +174,17 @@ describe("POST /api/auth/register-from-project-pilot", () => {
     // A fresh token is minted — the old raw value is gone for good.
     expect(body.apiToken).toMatch(/^pf_/);
     expect(apiToken.create).toHaveBeenCalledTimes(1);
-    // The old row is revoked, not left dangling as a second active token.
-    expect(apiToken.update).toHaveBeenCalledTimes(1);
-    expect(apiToken.update.mock.calls[0][0].where.id).toBe("tok-existing");
-    expect(apiToken.update.mock.calls[0][0].data.revokedAt).toBeInstanceOf(Date);
+    // Any currently-active project-pilot token(s) for this user are revoked
+    // in bulk (not read-then-update-by-id), so a concurrent racing call
+    // can't leave two tokens active — see the route's inline comment.
+    expect(apiToken.updateMany).toHaveBeenCalledTimes(1);
+    const revokeArg = apiToken.updateMany.mock.calls[0][0];
+    expect(revokeArg.where).toEqual({
+      userId: "user-existing",
+      name: "project-pilot",
+      revokedAt: null,
+    });
+    expect(revokeArg.data.revokedAt).toBeInstanceOf(Date);
   });
 
   it("403 when ALLOWED_GITHUB_LOGINS is set and login is not in list", async () => {
@@ -214,8 +222,7 @@ describe("POST /api/auth/register-from-project-pilot", () => {
       });
       user.findUnique.mockResolvedValue(null);
       user.create.mockResolvedValue({ id: "user-ok", githubLogin: "ok-user" });
-      apiToken.findFirst.mockResolvedValue(null);
-
+  
       const res = await POST(makeReq({ githubAccessToken: "valid" }));
 
       expect(res.status).toBe(200);
@@ -234,7 +241,6 @@ describe("POST /api/auth/register-from-project-pilot", () => {
     });
     user.findUnique.mockResolvedValue(null);
     user.create.mockResolvedValue({ id: "user-1" });
-    apiToken.findFirst.mockResolvedValue(null);
     apiToken.create.mockResolvedValue({});
 
     await POST(makeReq({ githubAccessToken: "gho_oauth_token", githubLogin: "newbie" }));
@@ -258,7 +264,6 @@ describe("POST /api/auth/register-from-project-pilot", () => {
       githubPat: null,
     });
     user.update.mockResolvedValue({ id: "user-existing" });
-    apiToken.findFirst.mockResolvedValue({ id: "tok-existing", tokenHash: "irrelevant-hash", revokedAt: null });
 
     await POST(makeReq({ githubAccessToken: "gho_fresh_token" }));
 
@@ -281,7 +286,6 @@ describe("POST /api/auth/register-from-project-pilot", () => {
       githubPat: "",
     });
     user.update.mockResolvedValue({ id: "user-existing" });
-    apiToken.findFirst.mockResolvedValue({ id: "tok-existing", tokenHash: "irrelevant-hash", revokedAt: null });
 
     await POST(makeReq({ githubAccessToken: "gho_backfilled" }));
 
@@ -304,7 +308,6 @@ describe("POST /api/auth/register-from-project-pilot", () => {
       githubPat: "gho_old_narrow_scope_token",
     });
     user.update.mockResolvedValue({ id: "user-existing" });
-    apiToken.findFirst.mockResolvedValue({ id: "tok-existing", tokenHash: "irrelevant-hash", revokedAt: null });
 
     await POST(makeReq({ githubAccessToken: "gho_new_token_with_workflow" }));
 
@@ -326,7 +329,6 @@ describe("POST /api/auth/register-from-project-pilot", () => {
       githubPat: "github_pat_manual_finegrained",
     });
     user.update.mockResolvedValue({ id: "user-existing" });
-    apiToken.findFirst.mockResolvedValue({ id: "tok-existing", tokenHash: "irrelevant-hash", revokedAt: null });
 
     await POST(makeReq({ githubAccessToken: "gho_should_be_ignored" }));
 
@@ -348,7 +350,6 @@ describe("POST /api/auth/register-from-project-pilot", () => {
       githubPat: "ghp_manual_classic_pat",
     });
     user.update.mockResolvedValue({ id: "user-existing" });
-    apiToken.findFirst.mockResolvedValue({ id: "tok-existing", tokenHash: "irrelevant-hash", revokedAt: null });
 
     await POST(makeReq({ githubAccessToken: "gho_should_be_ignored" }));
 

--- a/tests/integration/register-from-project-pilot.test.ts
+++ b/tests/integration/register-from-project-pilot.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, beforeAll } from "vitest";
 
 // Mock the Prisma client before importing the route.
 vi.mock("@/lib/db", async () => {
@@ -7,7 +7,7 @@ vi.mock("@/lib/db", async () => {
     ...actual,
     prisma: {
       user: { findUnique: vi.fn(), update: vi.fn(), create: vi.fn() },
-      apiToken: { findFirst: vi.fn(), create: vi.fn() },
+      apiToken: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
     },
   };
 });
@@ -34,6 +34,7 @@ const user = prisma.user as unknown as {
 const apiToken = prisma.apiToken as unknown as {
   findFirst: ReturnType<typeof vi.fn>;
   create: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
 };
 
 function makeReq(body: unknown): NextRequest {
@@ -45,6 +46,10 @@ function makeReq(body: unknown): NextRequest {
 }
 
 describe("POST /api/auth/register-from-project-pilot", () => {
+  beforeAll(() => {
+    process.env.NEXTAUTH_SECRET = "test-hash-secret";
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -138,7 +143,7 @@ describe("POST /api/auth/register-from-project-pilot", () => {
     expect(user.update).not.toHaveBeenCalled();
   });
 
-  it("is idempotent: returns the existing active token on repeat calls", async () => {
+  it("invalidates + re-issues on repeat calls (hash-at-rest means the old raw value can't be recovered)", async () => {
     fetchMock.mockResolvedValue({
       id: 99,
       login: "returning",
@@ -154,17 +159,24 @@ describe("POST /api/auth/register-from-project-pilot", () => {
     user.update.mockResolvedValue({ id: "user-existing" });
     apiToken.findFirst.mockResolvedValue({
       id: "tok-existing",
-      token: "pf_existing_token_value",
+      tokenHash: "hash-of-a-token-we-no-longer-have-the-raw-value-for",
       userId: "user-existing",
       revokedAt: null,
     });
+    apiToken.update.mockResolvedValue({ id: "tok-existing", revokedAt: new Date() });
+    apiToken.create.mockResolvedValue({});
 
     const res = await POST(makeReq({ githubAccessToken: "valid" }));
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.apiToken).toBe("pf_existing_token_value");
-    expect(apiToken.create).not.toHaveBeenCalled();
+    // A fresh token is minted — the old raw value is gone for good.
+    expect(body.apiToken).toMatch(/^pf_/);
+    expect(apiToken.create).toHaveBeenCalledTimes(1);
+    // The old row is revoked, not left dangling as a second active token.
+    expect(apiToken.update).toHaveBeenCalledTimes(1);
+    expect(apiToken.update.mock.calls[0][0].where.id).toBe("tok-existing");
+    expect(apiToken.update.mock.calls[0][0].data.revokedAt).toBeInstanceOf(Date);
   });
 
   it("403 when ALLOWED_GITHUB_LOGINS is set and login is not in list", async () => {
@@ -246,7 +258,7 @@ describe("POST /api/auth/register-from-project-pilot", () => {
       githubPat: null,
     });
     user.update.mockResolvedValue({ id: "user-existing" });
-    apiToken.findFirst.mockResolvedValue({ token: "pf_x", revokedAt: null });
+    apiToken.findFirst.mockResolvedValue({ id: "tok-existing", tokenHash: "irrelevant-hash", revokedAt: null });
 
     await POST(makeReq({ githubAccessToken: "gho_fresh_token" }));
 
@@ -269,7 +281,7 @@ describe("POST /api/auth/register-from-project-pilot", () => {
       githubPat: "",
     });
     user.update.mockResolvedValue({ id: "user-existing" });
-    apiToken.findFirst.mockResolvedValue({ token: "pf_x", revokedAt: null });
+    apiToken.findFirst.mockResolvedValue({ id: "tok-existing", tokenHash: "irrelevant-hash", revokedAt: null });
 
     await POST(makeReq({ githubAccessToken: "gho_backfilled" }));
 
@@ -292,7 +304,7 @@ describe("POST /api/auth/register-from-project-pilot", () => {
       githubPat: "gho_old_narrow_scope_token",
     });
     user.update.mockResolvedValue({ id: "user-existing" });
-    apiToken.findFirst.mockResolvedValue({ token: "pf_x", revokedAt: null });
+    apiToken.findFirst.mockResolvedValue({ id: "tok-existing", tokenHash: "irrelevant-hash", revokedAt: null });
 
     await POST(makeReq({ githubAccessToken: "gho_new_token_with_workflow" }));
 
@@ -314,7 +326,7 @@ describe("POST /api/auth/register-from-project-pilot", () => {
       githubPat: "github_pat_manual_finegrained",
     });
     user.update.mockResolvedValue({ id: "user-existing" });
-    apiToken.findFirst.mockResolvedValue({ token: "pf_x", revokedAt: null });
+    apiToken.findFirst.mockResolvedValue({ id: "tok-existing", tokenHash: "irrelevant-hash", revokedAt: null });
 
     await POST(makeReq({ githubAccessToken: "gho_should_be_ignored" }));
 
@@ -336,7 +348,7 @@ describe("POST /api/auth/register-from-project-pilot", () => {
       githubPat: "ghp_manual_classic_pat",
     });
     user.update.mockResolvedValue({ id: "user-existing" });
-    apiToken.findFirst.mockResolvedValue({ token: "pf_x", revokedAt: null });
+    apiToken.findFirst.mockResolvedValue({ id: "tok-existing", tokenHash: "irrelevant-hash", revokedAt: null });
 
     await POST(makeReq({ githubAccessToken: "gho_should_be_ignored" }));
 

--- a/tests/integration/register-from-project-pilot.test.ts
+++ b/tests/integration/register-from-project-pilot.test.ts
@@ -222,7 +222,7 @@ describe("POST /api/auth/register-from-project-pilot", () => {
       });
       user.findUnique.mockResolvedValue(null);
       user.create.mockResolvedValue({ id: "user-ok", githubLogin: "ok-user" });
-  
+
       const res = await POST(makeReq({ githubAccessToken: "valid" }));
 
       expect(res.status).toBe(200);

--- a/tests/unit/db-helpers.test.ts
+++ b/tests/unit/db-helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, beforeAll } from "vitest";
 
 /**
  * Unit tests for the DB helper functions in lib/db.ts.
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   apiToken: {
     findUnique: vi.fn(),
     update: vi.fn(),
+    create: vi.fn(),
   },
   usageLog: {
     count: vi.fn(),
@@ -24,9 +25,20 @@ vi.mock("@prisma/client", () => ({
   }),
 }));
 
-import { validateApiToken, checkRateLimit, generateApiToken } from "@/lib/db";
+import {
+  validateApiToken,
+  checkRateLimit,
+  generateApiToken,
+  hashApiToken,
+  tokenPrefixOf,
+  createApiToken,
+} from "@/lib/db";
 
 describe("validateApiToken", () => {
+  beforeAll(() => {
+    process.env.NEXTAUTH_SECRET = "test-hash-secret";
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -43,6 +55,16 @@ describe("validateApiToken", () => {
     expect(mocks.apiToken.findUnique).not.toHaveBeenCalled();
   });
 
+  it("looks up by the HMAC hash of the presented token, never the raw value", async () => {
+    mocks.apiToken.findUnique.mockResolvedValue(null);
+    await validateApiToken("pf_nonexistent");
+
+    expect(mocks.apiToken.findUnique).toHaveBeenCalledTimes(1);
+    const findArg = mocks.apiToken.findUnique.mock.calls[0][0];
+    expect(findArg.where.tokenHash).toBe(hashApiToken("pf_nonexistent"));
+    expect(findArg.where.tokenHash).not.toBe("pf_nonexistent");
+  });
+
   it("returns null when the DB record is not found (findUnique returns null)", async () => {
     mocks.apiToken.findUnique.mockResolvedValue(null);
     const result = await validateApiToken("pf_nonexistent");
@@ -53,7 +75,7 @@ describe("validateApiToken", () => {
   it("returns null when record.revokedAt is a non-null Date", async () => {
     mocks.apiToken.findUnique.mockResolvedValue({
       id: "tok-1",
-      token: "pf_revoked",
+      tokenHash: hashApiToken("pf_revoked"),
       revokedAt: new Date("2024-01-01T00:00:00Z"),
       user: { id: "user-1" },
     });
@@ -65,7 +87,7 @@ describe("validateApiToken", () => {
   it("calls apiToken.update with lastUsedAt when token is valid", async () => {
     const record = {
       id: "tok-2",
-      token: "pf_valid",
+      tokenHash: hashApiToken("pf_valid"),
       revokedAt: null,
       user: { id: "user-2", email: "u@test.com" },
     };
@@ -83,7 +105,7 @@ describe("validateApiToken", () => {
   it("returns the full token record on a valid (non-revoked) token", async () => {
     const record = {
       id: "tok-3",
-      token: "pf_active",
+      tokenHash: hashApiToken("pf_active"),
       revokedAt: null,
       userId: "user-3",
       user: { id: "user-3", email: "a@b.com" },
@@ -93,6 +115,119 @@ describe("validateApiToken", () => {
 
     const result = await validateApiToken("pf_active");
     expect(result).toEqual(record);
+  });
+
+  it("rejects a wrong/invalid token even when a differently-keyed record exists", async () => {
+    // Simulate the DB only holding the hash for a *different* raw token —
+    // findUnique correctly returns null because the hashes don't match.
+    mocks.apiToken.findUnique.mockImplementation(({ where }) =>
+      where.tokenHash === hashApiToken("pf_correct_value")
+        ? Promise.resolve({ id: "tok-4", revokedAt: null, user: { id: "user-4" } })
+        : Promise.resolve(null)
+    );
+
+    const validResult = await validateApiToken("pf_correct_value");
+    const invalidResult = await validateApiToken("pf_wrong_guess");
+
+    expect(validResult).not.toBeNull();
+    expect(invalidResult).toBeNull();
+  });
+});
+
+describe("hashApiToken / tokenPrefixOf", () => {
+  beforeAll(() => {
+    process.env.NEXTAUTH_SECRET = "test-hash-secret";
+  });
+
+  it("is deterministic: the same raw token always hashes to the same value", () => {
+    expect(hashApiToken("pf_sample")).toBe(hashApiToken("pf_sample"));
+  });
+
+  it("produces different hashes for different raw tokens", () => {
+    expect(hashApiToken("pf_one")).not.toBe(hashApiToken("pf_two"));
+  });
+
+  it("produces a 64-char hex digest (SHA-256)", () => {
+    expect(hashApiToken("pf_sample")).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is keyed: the same raw token hashes differently under a different secret", () => {
+    const a = hashApiToken("pf_sample");
+    process.env.NEXTAUTH_SECRET = "a-different-secret";
+    const b = hashApiToken("pf_sample");
+    process.env.NEXTAUTH_SECRET = "test-hash-secret";
+    expect(a).not.toBe(b);
+  });
+
+  it("throws when no hash secret is configured", () => {
+    const original = process.env.NEXTAUTH_SECRET;
+    delete process.env.NEXTAUTH_SECRET;
+    delete process.env.API_TOKEN_HASH_SECRET;
+    try {
+      expect(() => hashApiToken("pf_sample")).toThrow(/API_TOKEN_HASH_SECRET/);
+    } finally {
+      process.env.NEXTAUTH_SECRET = original;
+    }
+  });
+
+  it("prefers API_TOKEN_HASH_SECRET over NEXTAUTH_SECRET when both are set", () => {
+    process.env.API_TOKEN_HASH_SECRET = "dedicated-secret";
+    const withDedicated = hashApiToken("pf_sample");
+    delete process.env.API_TOKEN_HASH_SECRET;
+    const withFallback = hashApiToken("pf_sample");
+    expect(withDedicated).not.toBe(withFallback);
+  });
+
+  it("tokenPrefixOf returns the first 10 characters of the raw token", () => {
+    expect(tokenPrefixOf("pf_abcdefghijklmnop")).toBe("pf_abcdefg");
+  });
+});
+
+describe("createApiToken", () => {
+  beforeAll(() => {
+    process.env.NEXTAUTH_SECRET = "test-hash-secret";
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("persists only the hash + prefix, never the raw token", async () => {
+    mocks.apiToken.create.mockImplementation(({ data }) =>
+      Promise.resolve({ id: "tok-new", ...data })
+    );
+
+    const { raw, record } = await createApiToken({ apiToken: mocks.apiToken }, "user-1", "ci");
+
+    expect(raw).toMatch(/^pf_/);
+    expect(mocks.apiToken.create).toHaveBeenCalledTimes(1);
+    const createArg = mocks.apiToken.create.mock.calls[0][0];
+    expect(createArg.data).not.toHaveProperty("token");
+    expect(createArg.data.tokenHash).toBe(hashApiToken(raw));
+    expect(createArg.data.tokenPrefix).toBe(tokenPrefixOf(raw));
+    expect(createArg.data.userId).toBe("user-1");
+    expect(createArg.data.name).toBe("ci");
+    expect(record.tokenHash).toBe(hashApiToken(raw));
+    // The raw value must never appear anywhere in what got persisted.
+    expect(JSON.stringify(createArg)).not.toContain(raw);
+  });
+
+  it("the returned raw token round-trips through validateApiToken's hash lookup", async () => {
+    mocks.apiToken.create.mockImplementation(({ data }) =>
+      Promise.resolve({ id: "tok-rt", revokedAt: null, user: { id: "user-1" }, ...data })
+    );
+
+    const { raw } = await createApiToken({ apiToken: mocks.apiToken }, "user-1", "ci");
+
+    mocks.apiToken.findUnique.mockImplementation(({ where }) =>
+      where.tokenHash === hashApiToken(raw)
+        ? Promise.resolve({ id: "tok-rt", revokedAt: null, user: { id: "user-1" } })
+        : Promise.resolve(null)
+    );
+    mocks.apiToken.update.mockResolvedValue({});
+
+    const validated = await validateApiToken(raw);
+    expect(validated).not.toBeNull();
   });
 });
 

--- a/tests/unit/hash-parity.test.ts
+++ b/tests/unit/hash-parity.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { hashApiToken as libHashApiToken, tokenPrefixOf as libTokenPrefixOf } from "@/lib/db";
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const scriptHash = require("../../scripts/backfill-api-token-hashes.js") as {
+  hashApiToken: (rawToken: string) => string;
+  tokenPrefixOf: (rawToken: string) => string;
+};
+
+/**
+ * Drift guard for the deliberate duplication between lib/db.ts's
+ * hashApiToken()/tokenPrefixOf() and their re-implementation in
+ * scripts/backfill-api-token-hashes.js (a plain-CJS ops script that can't
+ * `import` the TS module directly — see that script's header comment).
+ * If either formula ever changes without updating the other, this test
+ * fails instead of the drift silently producing tokens the migration
+ * script would hash differently from the app.
+ */
+describe("hash-parity: lib/db.ts vs scripts/backfill-api-token-hashes.js", () => {
+  beforeAll(() => {
+    process.env.NEXTAUTH_SECRET = "shared-parity-test-secret";
+  });
+
+  it("produce identical hashApiToken output for the same input and secret", () => {
+    const raw = "pf_someRepresentativeRawTokenValue123";
+    expect(scriptHash.hashApiToken(raw)).toBe(libHashApiToken(raw));
+  });
+
+  it("produce identical tokenPrefixOf output for the same input", () => {
+    const raw = "pf_anotherRawTokenValueForPrefixCheck";
+    expect(scriptHash.tokenPrefixOf(raw)).toBe(libTokenPrefixOf(raw));
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up to PR #107 (which removed the raw githubPat from GET /api/dashboard). The same response still returned apiTokens[].token in full and the settings page rendered every token raw, despite its own copy claiming tokens are shown only once. Tokens were stored in plaintext and re-served on every dashboard load.

- ApiToken now stores tokenHash (keyed HMAC-SHA256, @unique) + a non-secret tokenPrefix instead of a plaintext token column. validateApiToken looks up by tokenHash (keeps the O(1) unique-index lookup on the auth path).
- The raw token is returned exactly once at creation; GET /api/dashboard returns only id/name/tokenPrefix/createdAt/lastUsedAt. settings/page.tsx shows the raw token once (copy-to-clipboard) and a masked identifier thereafter.
- register-from-project-pilot's reuse branch (impossible under a one-way hash) becomes revoke+re-issue, atomic via prisma.$transaction + updateMany (userId+name scoped).

## Migration (operator decision)
Hash-in-place, expand/contract, via scripts/backfill-api-token-hashes.js: expand (additive: backfill tokenHash/tokenPrefix, keep token + old index) is safe alongside the old code; --contract (drop token + old index) runs only after the old code is stopped. Runbook in the script header: expand -> stop old container -> re-run expand -> --contract -> start new container. Fail-loud NULL-token guard; both phases idempotent. Verified across scratch-SQLite scenarios; NO prod DB touched.

**Load-bearing risk:** rotating NEXTAUTH_SECRET (or first-time setting API_TOKEN_HASH_SECRET) invalidates every issued token. This is why the merge is held for your sign-off on the migration choice.

## Tests
- 276 tests (hashApiToken/tokenPrefixOf, tokenHash-based validateApiToken, dashboard never-leaks with a raw sentinel, hash-parity guard, register race via $transaction, and a child-process integration test of the backfill script's expand/contract/fail-loud/idempotency). tsc + lint + coverage thresholds + next build all clean.

## Review
Reviewer subagent across two rounds: approve (accept_with_notes). Migration verified over 9 SQLite scenarios (data-loss-refuse and fail-loud NULL guard both reproduced); hash-parity watertight; no token/hash value ever logged. Broker contract (sole caller = project-pilot OAuth completion, no 401 retry loop) verified by the orchestrator against the project-pilot repo.

## Merge hold
Held for operator sign-off on the plaintext-token migration choice (lockout risk on secret rotation).

Refs: agent-tasks 4714addb, PR #107