### PR TITLE
fix(deps): bump js-yaml 4.3.0 -> 4.3.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6567,9 +6567,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Security: js-yaml 4.3.0 -> 4.3.1 (GHSA-5p4m-2wfm-xmqj / CVE-2026-59870)

Fleet-wide sweep closing the js-yaml HIGH advisory (quadratic CPU consumption in `!!omap` resolution; vulnerable `>=4.0.0 <4.3.1`, fixed in 4.3.1). Task: b1dcb3e0 (depsight project).

**Change:** lockfile-only, single version move `js-yaml 4.3.0 -> 4.3.1` (js-yaml is production-reachable via swagger-client/swagger-ui-react. The pre-existing package.json override js-yaml ^4.2.0 intentionally supersedes swagger-ui-react@5.32.11 exact pin =4.3.0; reviewer verified the override is load-bearing by counterfactual resolution. Re-check that pin on the next swagger-ui-react upgrade. npm audits own fix suggestion, a swagger-ui-react downgrade to 3.51.2, was correctly NOT taken). No package.json change, no majors, no other dependency drift.

**Verification (per cve-sweep recipe):**
- `npm audit --audit-level=high` exit 0 on the fixed tree(s)
- Lockfile key diff vs base: no removed entries, no nested records dropped, only js-yaml version changes
- Coherence gate: clean `git archive` extract, `npm ci --dry-run --no-audit --no-fund --ignore-scripts` under the CI npm version npm 10.8.2, CI node 20, CI-exact --legacy-peer-deps flags plus the stricter plain dry-run, exit 0 on branch and base (attribution control)
- Independent reviewer subagent: APPROVE override-deletion counterfactual, base-audit-red vs branch-green control, quadratic blowup measured absent in 4.3.1 up to n=64k, 276 tests green
