### PR TITLE
security: bump dompurify to 3.4.13 (GHSA-55q2-fjhq-7xh7, lockfile-only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4398,9 +4398,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5489,7 +5489,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
Lockfile-only bump of dompurify to 3.4.13 (GHSA-55q2-fjhq-7xh7, vulnerable <= 3.4.12, transitive).

Part of the 2026-08-12 CVE sweep. Verified: npm audit clean, npm ci --dry-run coherent under npm 10 and 11.

Note: the diff also drops a stale `"dev": true` flag on the fsevents record. Reviewer-attributed to latent npm-11 bookkeeping drift already in master's lockfile (a no-op `npm install --package-lock-only` on pristine master reproduces exactly this delta; `npm ci --omit=dev --dry-run` output is identical on both sides). Not tampering, intentionally not hand-reverted.